### PR TITLE
Make Claude model configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Claude API
 CLAUDE_API_KEY=
+CLAUDE_MODEL=claude-sonnet-4-5-20250929
 
 # Telegram
 TELEGRAM_BOT_TOKEN=

--- a/src/storebot/config.py
+++ b/src/storebot/config.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
 
     # Claude API
     claude_api_key: str = ""
+    claude_model: str = "claude-sonnet-4-5-20250929"
 
     # Telegram
     telegram_bot_token: str = ""


### PR DESCRIPTION
## Summary
- Add `claude_model` setting to `Settings` (default: `claude-sonnet-4-5-20250929`), configurable via `CLAUDE_MODEL` env var
- Extract duplicated API call block into `Agent._call_api()` helper
- Document the new variable in `.env.example`

## Test plan
- [x] `ruff check` passes
- [x] All 232 tests pass
- [ ] Verify model override works by setting `CLAUDE_MODEL` in `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)