### PR TITLE
Fix claude-review permissions to allow posting comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Change `pull-requests` and `issues` permissions from `read` to `write` in the `claude-review` CI job
- This is why the claude-review check has been passing silently without posting any review comments — it could read the diff but not write back

**This should be merged before #9** so that the marketing agent PR gets a proper code review.

## Test plan

- [ ] Merge this PR, then re-run CI on #9 and verify review comments appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)