### PR TITLE
Fix code-review plugin to post comments on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--allowedTools Bash(gh:*)'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

- Add `--comment` flag to code-review plugin prompt — the plugin outputs to terminal by default, this flag is required to post findings as PR comments
- Remove `--allowedTools Bash(gh:*)` — this overrode the default tool whitelist, leaving only Bash and removing Read/Glob/Grep that the plugin needs to analyze files

These are the remaining fixes needed after PR #10 (write permissions) and PR #11 (allowed tools). The review has been running successfully but output was going to terminal only, never posted.

**Merge before #9** so the marketing agent PR gets a proper review.

## Test plan

- [ ] Merge this, rebase #9, verify review comments appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)