### PR TITLE
Add Bash(gh:*) permission to claude-review CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          claude_args: '--allowedTools Bash(gh:*)'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

- Re-add `--allowedTools Bash(gh:*)` to the claude-review CI job

The code-review plugin needs Bash access to run `gh pr review` for posting comments. Without this, all Bash tool calls (including `gh` commands) are permission-denied.

Base tools (Read, Glob, Grep, Edit) are always available regardless of `--allowedTools` — the flag only controls additional tools like Bash and WebFetch.

**Merge before #9** so the marketing agent PR gets a proper review with comments.

## Test plan

- [ ] Merge this, rebase #9, verify review comments appear on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)