### PR TITLE
Fix FetchToken SOAP call using wrong parameter names

### DIFF
--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -287,7 +287,7 @@ class TraderaClient:
 
     @retry_on_transient()
     def _fetch_token_api_call(self, secret_key, headers):
-        return self.public_client.service.FetchToken(UserId=0, Token=secret_key, **headers)
+        return self.public_client.service.FetchToken(userId=0, secretKey=secret_key, **headers)
 
     def fetch_token(self, secret_key: str) -> dict:
         """Fetch user token after consent flow.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,8 +54,8 @@ class TestFetchToken:
         assert result["expires"] == "2027-01-01T00:00:00"
 
         call_kwargs = tradera_client._public_client.service.FetchToken.call_args.kwargs
-        assert call_kwargs["UserId"] == 0
-        assert call_kwargs["Token"] == "test-secret-key"
+        assert call_kwargs["userId"] == 0
+        assert call_kwargs["secretKey"] == "test-secret-key"
 
     def test_fetch_token_missing_fields(self, tradera_client):
         response = MagicMock()


### PR DESCRIPTION
## Summary
- Fixed `FetchToken` SOAP call passing `UserId`/`Token` instead of `userId`/`secretKey`, which don't match the Tradera PublicService API signature
- Updated test assertions to match the corrected parameter names

## Context
The `storebot-authorize-tradera` CLI command failed with:
```
TypeError: FetchToken() got an unexpected keyword argument 'Token'. Signature: `userId: xsd:int, secretKey: xsd:string`
```

Verified against [Tradera API docs](https://api.tradera.com/v3/publicservice.asmx) — the correct parameters are `userId` and `secretKey`.

## Test plan
- [x] All 4 `fetch_token` tests pass
- [x] Parameter names verified against Tradera PublicService documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)