### PR TITLE
Use Opus 4.6 for Claude workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,5 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          claude_args: '--allowedTools Bash(gh:*)'
+          claude_args: '--model claude-opus-4-6 --allowedTools Bash(gh:*)'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,8 +43,6 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Use Opus 4.6 for code reviews
+          claude_args: '--model claude-opus-4-6'
 


### PR DESCRIPTION
## Summary
- Switch both CI code review and ad-hoc `@claude` workflows to use Opus 4.6 (`claude-opus-4-6`) instead of the default Sonnet model
- Adds `--model claude-opus-4-6` to `claude_args` in both `ci.yml` and `claude.yml`

## Test plan
- [ ] Open a test PR and verify the CI `claude-review` job uses Opus 4.6
- [ ] Tag `@claude` in a PR comment and verify it uses Opus 4.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)