### PR TITLE
Document Tradera API messaging limitation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 
 ## External API Notes
 
-- **Tradera:** SOAP/XML API, rate limit 100 calls/24h (extendable). Sandbox via `sandbox=1`. Register at Tradera Developer Program.
+- **Tradera:** SOAP/XML API, rate limit 100 calls/24h (extendable). Sandbox via `sandbox=1`. Register at Tradera Developer Program. **No messaging/Q&A support** — the SOAP API has no methods for reading or answering buyer questions. Customer communication will require email integration.
 - **Blocket:** Unofficial, read-only. Bearer token extracted from browser session (expires, needs manual renewal).
 - **PostNord:** REST API for shipping labels. Sandbox: `atapi2.postnord.com`, production: `api2.postnord.com`. API key as query parameter. Service codes: `19` (MyPack Collect), `17` (MyPack Home), `18` (Postpaket).
 
@@ -101,6 +101,7 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 - MCP server wrappers for tool modules
 - sqlite-vec embeddings for semantic product search
 - Social media cross-posting
+- Customer message handling (requires email/IMAP — Tradera API has no messaging support)
 - Crop management, custom webshop, wishlist matching
 
 ## Build Phases

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ Tradera uses a SOAP/XML API for searching and listing items.
 
 **Rate limits:** 100 API calls per 24 hours (can request an increase from Tradera).
 
+**Customer messaging:** The Tradera SOAP API does not expose any methods for reading or answering buyer questions/messages. Customer communication handling will require email integration (parsing Tradera notification emails via IMAP).
+
 WSDL endpoints:
 - SearchService: `https://api.tradera.com/v3/searchservice.asmx?WSDL`
 - PublicService: `https://api.tradera.com/v3/publicservice.asmx?WSDL`


### PR DESCRIPTION
## Summary
- Document that the Tradera SOAP API has no methods for reading or answering buyer questions/messages
- Add note to CLAUDE.md (External API Notes + Not started section) and README.md (Tradera setup section)
- Future customer communication handling will require email/IMAP integration

## Test plan
- [x] Verify CLAUDE.md changes are correct
- [x] Verify README.md changes are correct
- [x] No code changes — markdown only

🤖 Generated with [Claude Code](https://claude.com/claude-code)