### PR TITLE
Add product archiving and unarchiving

### DIFF
--- a/alembic/versions/89b76ef106cb_add_previous_status_to_products.py
+++ b/alembic/versions/89b76ef106cb_add_previous_status_to_products.py
@@ -1,0 +1,30 @@
+"""add previous_status to products
+
+Revision ID: 89b76ef106cb
+Revises: ea950e4c057e
+Create Date: 2026-02-13 12:59:40.783003
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '89b76ef106cb'
+down_revision: Union[str, Sequence[str], None] = 'ea950e4c057e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table('products', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('previous_status', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('products', schema=None) as batch_op:
+        batch_op.drop_column('previous_status')

--- a/src/storebot/agent.py
+++ b/src/storebot/agent.py
@@ -242,6 +242,8 @@ class Agent:
         "search_products": ("listing", "search_products"),
         "create_product": ("listing", "create_product"),
         "save_product_image": ("listing", "save_product_image"),
+        "archive_product": ("listing", "archive_product"),
+        "unarchive_product": ("listing", "unarchive_product"),
         "check_new_orders": ("order", "check_new_orders"),
         "list_orders": ("order", "list_orders"),
         "get_order": ("order", "get_order"),

--- a/src/storebot/db.py
+++ b/src/storebot/db.py
@@ -20,6 +20,7 @@ class Product(Base):
     description: Mapped[str | None] = mapped_column(Text)
     category: Mapped[str | None] = mapped_column(String)
     status: Mapped[str] = mapped_column(String, default="draft")  # draft/listed/sold/archived
+    previous_status: Mapped[str | None] = mapped_column(String)
     acquisition_cost: Mapped[float | None] = mapped_column(Float)
     listing_price: Mapped[float | None] = mapped_column(Float)
     sold_price: Mapped[float | None] = mapped_column(Float)

--- a/src/storebot/tools/definitions.py
+++ b/src/storebot/tools/definitions.py
@@ -384,7 +384,7 @@ TOOLS = [
     },
     {
         "name": "search_products",
-        "description": "Search the local product database.",
+        "description": "Search the local product database. Archived products are hidden by default.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -392,6 +392,11 @@ TOOLS = [
                 "status": {
                     "type": "string",
                     "description": "Filter by status: draft, listed, sold, archived",
+                },
+                "include_archived": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Include archived products in results (default false)",
                 },
             },
         },
@@ -448,6 +453,28 @@ TOOLS = [
                 },
             },
             "required": ["product_id", "image_path"],
+        },
+    },
+    {
+        "name": "archive_product",
+        "description": "Archive a product, hiding it from normal search and listing views. Cannot archive products with active marketplace listings.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "product_id": {"type": "integer", "description": "Product ID to archive"},
+            },
+            "required": ["product_id"],
+        },
+    },
+    {
+        "name": "unarchive_product",
+        "description": "Restore an archived product to its previous status (draft, listed, etc.).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "product_id": {"type": "integer", "description": "Product ID to unarchive"},
+            },
+            "required": ["product_id"],
         },
     },
     {


### PR DESCRIPTION
## Summary
- Add `archive_product` and `unarchive_product` operations to ListingService with full audit trail
- Archived products are hidden from `search_products`, `list_drafts`, and blocked from `create_draft` by default
- Unarchiving restores the product to its previous status (draft, listed, etc.)
- Products with active marketplace listings cannot be archived
- Alembic migration adds `previous_status` column to products table

## Test plan
- [x] 502 tests passing (18 new tests for archive/unarchive/filtering)
- [x] `ruff check` and `ruff format --check` clean
- [ ] Manual: archive a draft product via Telegram, verify it disappears from search
- [ ] Manual: unarchive and verify it reappears with original status

🤖 Generated with [Claude Code](https://claude.com/claude-code)