### PR TITLE
Document sqlite3 as a system dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ All listings start as **drafts** requiring explicit approval before publishing.
 
 - Python 3.10+ (developed with 3.13)
 - [uv](https://docs.astral.sh/uv/) package manager
+- `sqlite3` CLI tool (`sudo apt install sqlite3` on Debian/Ubuntu) — required by the backup script
 - API keys for the services below
 
 ## Quick start
@@ -327,6 +328,9 @@ Backups include integrity verification, gzip compression, and automatic rotation
 A systemd service file is provided for production deployment.
 
 ```bash
+# Install system dependencies
+sudo apt install sqlite3
+
 # Create a system user
 sudo useradd -r -s /usr/sbin/nologin storebot
 


### PR DESCRIPTION
## Summary
- Add `sqlite3` CLI tool to the prerequisites section in README
- Add `sudo apt install sqlite3` to the Raspberry Pi deployment instructions
- The backup script (`deploy/backup.sh`) calls `sqlite3` directly, which may not be installed on a fresh Raspberry Pi, causing silent backup failures

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)