### PR TITLE
Add debug logging for FetchToken SOAP response

### DIFF
--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -431,6 +431,11 @@ class TraderaClient:
                 secret_key, self._auth_headers(self.public_client)
             )
 
+            from zeep.helpers import serialize_object
+
+            response_data = serialize_object(response)
+            logger.debug("FetchToken raw response: %s", response_data)
+
             user_id = getattr(response, "UserId", None)
             token = getattr(response, "Token", None)
             expires = getattr(response, "ExpirationDate", None)
@@ -438,7 +443,10 @@ class TraderaClient:
                 expires = str(expires)
 
             if user_id is None or token is None:
-                return {"error": "FetchToken response missing UserId or Token"}
+                return {
+                    "error": f"FetchToken response missing UserId or Token. "
+                    f"Raw response: {response_data}"
+                }
 
             return {
                 "user_id": user_id,


### PR DESCRIPTION
## Summary
- Serialize the raw SOAP response via `zeep.helpers.serialize_object` and log it at DEBUG level after `FetchToken` returns
- Include the serialized response in the error message when `UserId` or `Token` are missing, so the actual response structure is visible without guesswork

## Context
Running `storebot-authorize-tradera` on the Pi fails with "FetchToken response missing UserId or Token" even though the consent flow completed successfully. The error gives no visibility into what Tradera actually returned. Zeep SOAP responses can have nested or differently-named attributes depending on the WSDL, so we need to see the raw structure to fix the attribute access.

## Test plan
- [x] `ruff check` passes
- [x] All 48 tradera tests pass
- [x] All 12 CLI tests pass
- [ ] Run `storebot-authorize-tradera` on the Pi — error message now shows the raw response structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)