### PR TITLE
Improve FetchToken diagnostics for authorization debugging

### DIFF
--- a/src/storebot/cli.py
+++ b/src/storebot/cli.py
@@ -51,6 +51,8 @@ def authorize_tradera() -> None:
 
     print("Tradera Authorization")
     print("=" * 40)
+    print(f"  App ID:  {settings.tradera_app_id}")
+    print(f"  Sandbox: {settings.tradera_sandbox}")
     print()
     print("Open this URL in your browser and log in to grant access:")
     print()
@@ -68,6 +70,10 @@ def authorize_tradera() -> None:
 
     if "error" in result:
         print(f"\nError fetching token: {result['error']}")
+        if "sent_xml" in result:
+            print(f"\nSent SOAP request:\n{result['sent_xml']}")
+        if "response_repr" in result:
+            print(f"\nParsed response object: {result['response_repr']}")
         sys.exit(1)
 
     print()


### PR DESCRIPTION
## Summary
- Log the **outgoing SOAP request** (sent XML) alongside the received XML when FetchToken fails, to verify correct parameters and sandbox mode
- Print the **parsed response object** (`repr`) on failure for additional insight
- Show **App ID** and **Sandbox mode** in the CLI header so the user immediately sees the active configuration

## Context
FetchToken returns an empty `<FetchTokenResponse/>` after completing the consent flow. These diagnostics help identify whether the issue is a parameter mismatch, sandbox/production mode mismatch, or something on Tradera's side.

## Test plan
- [ ] Run `storebot-authorize-tradera` with a failing token fetch and verify sent XML, response repr, and config are printed
- [ ] Run with a successful token fetch and verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)