### PR TITLE
Add retry with backoff to FetchToken authorization

### DIFF
--- a/src/storebot/cli.py
+++ b/src/storebot/cli.py
@@ -2,6 +2,7 @@
 
 import re
 import sys
+import time
 import uuid
 from pathlib import Path
 
@@ -66,7 +67,18 @@ def authorize_tradera() -> None:
         sandbox=settings.tradera_sandbox,
     )
 
-    result = client.fetch_token(skey)
+    max_attempts = 3
+    delay = 3
+    result = None
+    for attempt in range(1, max_attempts + 1):
+        print(f"\nFetching token (attempt {attempt}/{max_attempts})...")
+        result = client.fetch_token(skey)
+        if "error" not in result:
+            break
+        if attempt < max_attempts:
+            print(f"  Token not ready yet, retrying in {delay}s...")
+            time.sleep(delay)
+            delay *= 2
 
     if "error" in result:
         print(f"\nError fetching token: {result['error']}")


### PR DESCRIPTION
## Summary
- Retry FetchToken up to 3 times with exponential backoff (3s → 6s) before failing
- Shows attempt progress so the user knows it's working
- Addresses empty `FetchTokenResponse` that may be a timing issue after consent redirect

## Context
After completing the Tradera consent flow, FetchToken returns an empty response. The consent completes (redirects to localhost:8080), but the token may not be immediately available. This adds retries to handle potential propagation delay on Tradera's side.

If retries still fail, the full diagnostics from #35 are shown.

## Test plan
- [ ] Run `storebot-authorize-tradera`, complete consent, verify retry output
- [ ] Verify successful token fetch still works on first attempt without unnecessary delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)