### PR TITLE
Add file logging and API token usage logging

### DIFF
--- a/src/storebot/agent.py
+++ b/src/storebot/agent.py
@@ -158,13 +158,20 @@ class Agent:
 
     def _call_api(self, messages: list[dict]):
         """Send messages to Claude and return the response."""
-        return self.client.messages.create(
+        response = self.client.messages.create(
             model=self.settings.claude_model,
             max_tokens=4096,
             system=SYSTEM_PROMPT,
             messages=messages,
             tools=TOOLS,
         )
+        logger.info(
+            "API call: input_tokens=%d, output_tokens=%d, stop_reason=%s",
+            response.usage.input_tokens,
+            response.usage.output_tokens,
+            response.stop_reason,
+        )
+        return response
 
     def handle_message(
         self,
@@ -174,6 +181,12 @@ class Agent:
     ) -> AgentResponse:
         if conversation_history is None:
             conversation_history = []
+
+        logger.info(
+            "handle_message: history_messages=%d, has_images=%s",
+            len(conversation_history),
+            bool(image_paths),
+        )
 
         if image_paths:
             content = []

--- a/src/storebot/bot/handlers.py
+++ b/src/storebot/bot/handlers.py
@@ -324,7 +324,9 @@ async def poll_orders_job(context: ContextTypes.DEFAULT_TYPE) -> None:
 def main() -> None:
     settings = get_settings()
 
-    configure_logging(level=settings.log_level, json_format=settings.log_json)
+    configure_logging(
+        level=settings.log_level, json_format=settings.log_json, log_file=settings.log_file
+    )
 
     _validate_credentials(settings)
 

--- a/src/storebot/config.py
+++ b/src/storebot/config.py
@@ -58,6 +58,7 @@ class Settings(BaseSettings):
     # Logging
     log_level: str = "INFO"
     log_json: bool = True
+    log_file: str = ""
 
 
 def get_settings() -> Settings:


### PR DESCRIPTION
## Summary
- Add `LOG_FILE` setting with `RotatingFileHandler` (10 MB max, 3 backups) so logs persist to disk on the Pi instead of relying solely on stdout/journalctl
- Log `input_tokens`, `output_tokens`, and `stop_reason` on every Claude API call for visibility into token usage and context growth
- Log conversation history message count entering `handle_message` to correlate growing context with failures
- Auto-create parent directories for the log file path

## Test plan
- [x] `ruff check` and `ruff format --check` pass
- [x] All 511 tests pass (4 new tests for file handler: added, writes, creates parent dirs, empty string no-op)
- [ ] Set `LOG_FILE=/tmp/storebot.log` in `.env`, run locally, send a message, verify log file contains token usage entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)