### PR TITLE
Fix logging config being overwritten by Alembic

### DIFF
--- a/src/storebot/bot/handlers.py
+++ b/src/storebot/bot/handlers.py
@@ -337,13 +337,13 @@ async def poll_orders_job(context: ContextTypes.DEFAULT_TYPE) -> None:
 def main() -> None:
     settings = get_settings()
 
+    engine = init_db()
+
     configure_logging(
         level=settings.log_level, json_format=settings.log_json, log_file=settings.log_file
     )
 
     _validate_credentials(settings)
-
-    engine = init_db()
 
     app = Application.builder().token(settings.telegram_bot_token).build()
 


### PR DESCRIPTION
## Summary
- Move `configure_logging()` to after `init_db()` in `main()`
- Alembic's `env.py` calls `fileConfig()` during migrations, which resets the root logger and discards all handlers — this was silently wiping out the configured log level, log file, and JSON formatter
- With this fix, `LOG_LEVEL`, `LOG_FILE`, and `LOG_JSON` settings from `.env` are properly applied

## Test plan
- [ ] Deploy and verify agent API call logs (`API call: input_tokens=...`) appear in `/opt/storebot/data/storebot.log`
- [ ] Verify DEBUG-level tool execution logs appear when `LOG_LEVEL=DEBUG`
- [ ] Run `pytest` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)