### PR TITLE
Fix 5 Tradera SOAP calls to match WSDL specification

### DIFF
--- a/src/storebot/tools/definitions.py
+++ b/src/storebot/tools/definitions.py
@@ -168,16 +168,10 @@ TOOLS = [
     },
     {
         "name": "get_categories",
-        "description": "Browse Tradera categories. Use to find the right category ID for a listing.",
+        "description": "Get all Tradera categories. Use to find the right category ID for a listing.",
         "input_schema": {
             "type": "object",
-            "properties": {
-                "parent_id": {
-                    "type": "integer",
-                    "description": "Parent category ID (0 for top-level categories)",
-                    "default": 0,
-                },
-            },
+            "properties": {},
         },
     },
     {


### PR DESCRIPTION
## Summary

- Audited all 11 Tradera SOAP calls against actual WSDLs — fixed 5 mismatches (2 broken, 3 risky)
- **GetSellerOrders**: corrected field names (`FromDate`/`ToDate`) and added required `QueryDateMode` — confirmed broken in production
- **AddItemImage**: replaced nonexistent `AddItemImages` (plural) with per-image `AddItemImage` calls using correct WSDL params (`requestId`, `imageData`, `imageFormat`, `hasMega`)
- **AddItem**: wrapped kwargs in `itemRequest` named parameter per WSDL signature
- **GetCategories**: removed phantom `ParentCategoryId` param (WSDL takes no params), updated tool definition schema
- **GetItem**: fixed parameter casing `ItemId` → `itemId`

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `pytest tests/test_tradera.py -v` — 49/49 passed (including new `test_unknown_media_type_defaults_to_jpeg`)
- [x] `pytest` — 563/563 passed (full suite)
- [ ] Manual smoke test against Tradera sandbox for `GetSellerOrders` and `AddItemImage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)