### PR TITLE
Update stale counts and missing entries in docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,11 +35,28 @@ POSTNORD_SENDER_EMAIL=
 # Order polling interval in minutes
 ORDER_POLL_INTERVAL_MINUTES=30
 
+# Scheduled jobs (hour of day, 0-23)
+SCOUT_DIGEST_HOUR=8
+MARKETING_REFRESH_HOUR=7
+
+# Conversation history
+MAX_HISTORY_MESSAGES=20
+CONVERSATION_TIMEOUT_MINUTES=60
+
 # Database (SQLite path, relative to working directory)
 DATABASE_PATH=data/storebot.db
 
 # Voucher PDF export path (optional, has default)
 # VOUCHER_EXPORT_PATH=data/vouchers
 
+# Access control (comma-separated Telegram chat IDs, empty = all allowed)
+# ALLOWED_CHAT_IDS=
+
+# Rate limiting
+RATE_LIMIT_MESSAGES=30
+RATE_LIMIT_WINDOW_SECONDS=60
+
 # Logging
 LOG_LEVEL=INFO
+LOG_JSON=true
+# LOG_FILE=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,15 @@ Telegram Bot → Claude API (direct tool use, no framework)
 Agent Tool Modules (plain Python, MCP-wrappable later)
     ├── tools/tradera.py     (SOAP via zeep)
     ├── tools/blocket.py     (REST, read-only/research)
+    ├── tools/listing.py     (draft workflow, product mgmt, publish)
+    ├── tools/pricing.py     (cross-platform price analysis)
+    ├── tools/order.py       (order import, vouchers, shipping)
     ├── tools/accounting.py  (local vouchers + PDF export)
+    ├── tools/analytics.py   (business reports, profitability, ROI)
     ├── tools/scout.py       (saved searches, dedup, digest)
     ├── tools/marketing.py   (listing performance, recommendations)
     ├── tools/postnord.py    (shipping labels)
+    ├── tools/conversation.py(history persistence per chat)
     └── tools/image.py       (Pillow: resize, optimize)
     ↓
 SQLite + sqlite-vec (operational + financial: inventory, listings, orders, vouchers, agent state, embeddings)
@@ -82,7 +87,7 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 - **Product management** — `create_product` (with all optional fields: condition, materials, era, dimensions, source, acquisition_cost, weight_grams) and `save_product_image` (with is_primary logic).
 - **Image processing** — `resize_for_listing` (1200px), `resize_for_analysis` (800px), `optimize_for_upload` (JPEG compress), `encode_image_base64`. All handle EXIF rotation and RGBA conversion.
 - **Accounting** — `AccountingService` with local voucher storage (SQLite), double-entry bookkeeping with BAS-kontoplan, PDF export (single + batch), debit/credit balance validation.
-- **Agent loop** — `agent.py` with Claude API tool loop, 44 tool definitions, vision support (base64 image content blocks), Swedish system prompt with image workflow guidance.
+- **Agent loop** — `agent.py` with Claude API tool loop, 45 tool definitions, vision support (base64 image content blocks), Swedish system prompt with image workflow guidance.
 - **Telegram bot** — `handlers.py` with `/start`, `/help`, `/new`, `/orders`, `/scout`, `/marketing`, `/rapport`, text message handling, and photo handling (download, resize, forward to agent with vision).
 - **Config** — Pydantic Settings from `.env`, all service credentials.
 - **Deployment** — systemd service file, SQLite backup script with cron rotation.
@@ -95,7 +100,7 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 - **Tradera authorization CLI** — `storebot-authorize-tradera` command for obtaining user tokens via consent flow. `TraderaClient.fetch_token()` calls `PublicService.FetchToken`. Saves credentials to `.env`.
 - **PostNord shipping labels** — `PostNordClient` REST client: `create_shipment()`, `get_label()`, `save_label()`. `Address` dataclass for sender/recipient, `parse_buyer_address()` for parsing Swedish addresses. Sandbox/production URL switching. Integrated into `OrderService.create_shipping_label()` with validation (weight, address), PDF label storage, tracking number persistence, and `AgentAction` audit trail.
 - **Resilience & observability** — Retry decorator with exponential backoff on transient errors (Tradera SOAP, Blocket REST, PostNord REST), structured JSON logging (`LOG_JSON` toggle), startup credential validation, admin alerts on scheduled job failures. SQLite WAL mode + busy timeout. Systemd restart limits, backup integrity checks with gzip compression.
-- **Tests** — 404 tests covering db, tradera, blocket, pricing, listing, image, order, accounting, conversation, scout, marketing, postnord, CLI, retry, logging, and handlers modules.
+- **Tests** — 563 tests across 18 modules covering db, tradera, blocket, pricing, listing, image, order, accounting, conversation, scout, marketing, analytics, postnord, CLI, retry, logging, handlers, and log_viewer.
 
 ### Not started
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,7 +20,7 @@ See [installation.md](installation.md) for full configuration reference.
 
 ```
 src/storebot/
-  agent.py             Claude API tool loop (44 tools, vision support)
+  agent.py             Claude API tool loop (45 tools, vision support)
   config.py            Pydantic Settings from .env
   db.py                SQLAlchemy 2.0 models (SQLite, 12 tables)
   cli.py               Tradera authorization CLI
@@ -29,7 +29,7 @@ src/storebot/
   bot/
     handlers.py        Telegram bot entry point (7 commands, photo handling, scheduled jobs)
   tools/
-    definitions.py     Tool schemas for Claude API (44 tool definitions)
+    definitions.py     Tool schemas for Claude API (45 tool definitions)
     tradera.py         Tradera SOAP API (search, create, upload, orders, shipping)
     blocket.py         Blocket unofficial REST API (price research)
     accounting.py      Local voucher storage + PDF export (BAS-kontoplan)
@@ -43,7 +43,9 @@ src/storebot/
     scout.py           Saved searches + dedup + daily digest
     marketing.py       Listing performance tracking + recommendations
     helpers.py         Shared utilities (log_action, naive_now)
-tests/                 pytest tests (17 modules)
+  tui/
+    log_viewer.py      Textual TUI for agent_actions audit log
+tests/                 pytest tests (18 modules)
 deploy/
   storebot.service     systemd unit file
   backup.sh            SQLite backup script (cron, gzip, integrity check)
@@ -67,8 +69,8 @@ User (Telegram) → handlers.py → agent.py → Claude API
 The agent loop in `agent.py` works as follows:
 
 1. Receives a user message (text and/or images) with conversation history
-2. Sends to Claude API with the system prompt and 44 tool definitions
-3. Claude responds with either text or tool use requests
+2. Sends to Claude API with the system prompt and 45 tool definitions
+3. Claude responds with either text or tool-use requests
 4. For each tool use request, the agent dispatches to the appropriate service method
 5. Tool results are sent back to Claude for further processing
 6. The loop continues until Claude responds with only text (no more tool calls)
@@ -205,7 +207,7 @@ pytest -v
 
 ### Test Modules
 
-17 test modules covering all core functionality:
+18 test modules covering all core functionality:
 
 | Module | Coverage |
 |--------|----------|
@@ -226,6 +228,7 @@ pytest -v
 | `test_retry.py` | Retry decorator, backoff behavior |
 | `test_logging_config.py` | JSON/human formatter, file handler |
 | `test_handlers.py` | Telegram command handlers, access control |
+| `test_log_viewer.py` | Audit log TUI data queries, filtering, sorting |
 
 ### Writing New Tests
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,12 +80,12 @@ Storebot includes local double-entry bookkeeping using the Swedish BAS-kontoplan
 
 ## Agent Tools
 
-The Claude agent has access to 44 tools organized by domain:
+The Claude agent has access to 45 tools organized by domain:
 
 | Domain | Count | Tools |
 |--------|-------|-------|
 | **Search** | 3 | `search_tradera`, `search_blocket`, `get_blocket_ad` |
-| **Products** | 6 | `create_product`, `save_product_image`, `search_products`, `get_product_images`, `archive_product`, `unarchive_product` |
+| **Products** | 7 | `create_product`, `update_product`, `save_product_image`, `search_products`, `get_product_images`, `archive_product`, `unarchive_product` |
 | **Listings** | 9 | `create_draft_listing`, `list_draft_listings`, `get_draft_listing`, `update_draft_listing`, `approve_draft_listing`, `reject_draft_listing`, `publish_listing`, `get_categories`, `get_shipping_options` |
 | **Orders** | 8 | `check_new_orders`, `list_orders`, `get_order`, `create_sale_voucher`, `mark_order_shipped`, `create_shipping_label`, `list_orders_pending_feedback`, `leave_feedback` |
 | **Accounting** | 2 | `create_voucher`, `export_vouchers` |


### PR DESCRIPTION
## Summary

- **Tool count:** 44→45 across CLAUDE.md, docs/usage.md, docs/development.md (`update_product` was missing)
- **Test count:** 404→563, 17→18 modules (`test_log_viewer.py` added with storebot-logs TUI)
- **Architecture diagram:** Added 5 missing tool modules (listing, pricing, order, analytics, conversation)
- **Project structure:** Added `tui/log_viewer.py` to development.md
- **usage.md:** Added `update_product` to Products tool table (count 6→7)
- **.env.example:** Added 9 missing config variables that exist in config.py (scheduling, conversation, access control, rate limiting, logging)

## Test plan

- [ ] Verify all counts match code: `grep -c "^{" src/storebot/tools/definitions.py` for tool defs, `ls tests/test_*.py | wc -l` for test modules
- [ ] Confirm .env.example variables match config.py fields
- [ ] No functional code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)