### PR TITLE
Fix: remove unsupported AcceptingReturns from Tradera API call

### DIFF
--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -197,7 +197,6 @@ class TraderaClient:
         shipping_cost: float | None = None,
         shipping_options: list[dict] | None = None,
         shipping_condition: str | None = None,
-        accepting_returns: bool = False,
     ) -> dict:
         """Create a listing on Tradera via RestrictedService AddItem."""
         try:
@@ -209,7 +208,6 @@ class TraderaClient:
                 "CategoryId": int(category_id),
                 "Duration": int(duration_days),
                 "ItemType": item_type,
-                "AcceptingReturns": accepting_returns,
             }
             if start_price is not None:
                 params["StartPrice"] = int(start_price)

--- a/tests/test_tradera.py
+++ b/tests/test_tradera.py
@@ -353,7 +353,7 @@ class TestTraderaCreateListing:
         assert item_req["ItemType"] == 2  # BuyItNow
         assert item_req["BuyItNowPrice"] == 800
 
-    def test_with_shipping_and_returns(self, client):
+    def test_with_shipping_cost(self, client):
         response = MagicMock()
         response.ItemId = 1
         client._restricted_client.service.AddItem.return_value = response
@@ -363,13 +363,11 @@ class TestTraderaCreateListing:
             description="Test",
             category_id=100,
             shipping_cost=99,
-            accepting_returns=True,
         )
 
         call_kwargs = client._restricted_client.service.AddItem.call_args.kwargs
         item_req = call_kwargs["itemRequest"]
         assert item_req["ShippingCost"] == 99
-        assert item_req["AcceptingReturns"] is True
 
     def test_uses_authorization_headers(self, client):
         response = MagicMock()


### PR DESCRIPTION
## Summary
- Removed `AcceptingReturns` parameter from `TraderaClient.create_listing()` — it is not in Tradera's `AddItem` SOAP schema and caused publishing to fail
- Updated test to match (renamed `test_with_shipping_and_returns` → `test_with_shipping_cost`)

## Test plan
- [x] All 596 tests pass
- [x] Ruff lint and format clean
- [ ] Retry publishing the listing that failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)