### PR TITLE
Fix missing AcceptedBidderId in Tradera AddItem request

### DIFF
--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -212,6 +212,7 @@ class TraderaClient:
                 "Restarts": 0,
                 "ItemType": item_type,
                 "AutoCommit": auto_commit,
+                "AcceptedBidderId": [],
             }
             if start_price is not None:
                 params["StartPrice"] = int(start_price)


### PR DESCRIPTION
## Summary
- Tradera API requires `AcceptedBidderId` element in AddItem requests, even when no bidder restriction is intended
- Added empty list `[]` as default value, which means all bidders are allowed (normal behavior)
- Without this field, Tradera rejects the request with: `Missing element AcceptedBidderId (AddItem.itemRequest.AcceptedBidderId)`

## Test plan
- [x] All 196 tradera + listing tests pass
- [ ] Verify publish flow works against Tradera sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)