### PR TITLE
Document Tradera restricted API access contact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 
 ## External API Notes
 
-- **Tradera:** SOAP/XML API, rate limit 100 calls/24h (extendable). Sandbox via `sandbox=1`. Register at Tradera Developer Program. **No messaging/Q&A support** — the SOAP API has no methods for reading or answering buyer questions. Customer communication will require email integration.
+- **Tradera:** SOAP/XML API, rate limit 100 calls/24h (extendable via apiadmin@tradera.com). Sandbox via `sandbox=1`. Register at Tradera Developer Program. Request restricted API access (RestrictedService, OrderService) by emailing apiadmin@tradera.com. **No messaging/Q&A support** — the SOAP API has no methods for reading or answering buyer questions. Customer communication will require email integration.
 - **Blocket:** Unofficial, read-only. Bearer token extracted from browser session (expires, needs manual renewal).
 - **PostNord:** REST API for shipping labels. Sandbox: `atapi2.postnord.com`, production: `api2.postnord.com`. API key as query parameter. Service codes: `19` (MyPack Collect), `17` (MyPack Home), `18` (Postpaket).
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -120,10 +120,11 @@ Tradera uses a SOAP/XML API for searching and listing items.
 
 1. Register at the [Tradera Developer Program](https://developer.tradera.com/)
 2. Create an application to get your `AppId` and `AppKey`
-3. Set `TRADERA_APP_ID` and `TRADERA_APP_KEY` in `.env`
-4. Keep `TRADERA_SANDBOX=true` during development
+3. **Request access to restricted APIs** by emailing [apiadmin@tradera.com](mailto:apiadmin@tradera.com) — this is required for creating listings, managing orders, and uploading images (RestrictedService and OrderService)
+4. Set `TRADERA_APP_ID` and `TRADERA_APP_KEY` in `.env`
+5. Keep `TRADERA_SANDBOX=true` during development
 
-**Rate limits:** 100 API calls per 24 hours (can request an increase from Tradera).
+**Rate limits:** 100 API calls per 24 hours (can request an increase from Tradera via [apiadmin@tradera.com](mailto:apiadmin@tradera.com)).
 
 **Customer messaging:** The Tradera SOAP API does not expose any methods for reading or answering buyer questions/messages. Customer communication handling will require email integration (parsing Tradera notification emails via IMAP).
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -244,7 +244,7 @@ Tradera allows 100 API calls per 24 hours by default. If you hit the limit:
 
 1. Check logs for rate limit errors
 2. Increase `ORDER_POLL_INTERVAL_MINUTES` to poll less frequently
-3. Request a rate limit increase from Tradera
+3. Request a rate limit increase by emailing [apiadmin@tradera.com](mailto:apiadmin@tradera.com)
 
 ### SQLite Lock Contention
 


### PR DESCRIPTION
## Summary
- Add `apiadmin@tradera.com` as the contact for requesting access to Tradera restricted APIs (RestrictedService, OrderService) in `docs/installation.md`
- Update rate limit increase instructions in `docs/installation.md` and `docs/maintenance.md` to reference the same email
- Update `CLAUDE.md` External API Notes with the contact info

## Test plan
- [ ] Verify markdown links render correctly in all three files

🤖 Generated with [Claude Code](https://claude.com/claude-code)