### PR TITLE
Fix API 400 error: replace anyOf nullable patterns with optional params

### DIFF
--- a/src/storebot/agent.py
+++ b/src/storebot/agent.py
@@ -172,7 +172,7 @@ _COMPACT_SYSTEM_PROMPT = (
 
 
 def _strip_nulls(value):
-    """Recursively remove None values from dicts/lists (strict mode sends null for omitted params).
+    """Recursively remove None values from dicts/lists.
 
     Empty dicts/lists that result from stripping are collapsed to None so
     that downstream ``is not None`` guards work correctly (e.g. details in


### PR DESCRIPTION
## Summary

- The Anthropic API now enforces a limit of 16 union-typed parameters (`anyOf`/type arrays) per request — our tool schemas had **83**, causing every Claude API call to fail with **400 Bad Request**
- Converted all `anyOf: [{type: X}, {type: null}]` nullable patterns to plain `{type: X}` optional parameters (omitted from `required` instead of sending `null`)
- Extracted shared `_EMPTY_SCHEMA` (7 tools) and `_PERIOD_SCHEMA` (4 tools) constants to reduce repetition
- Net result: **-184 lines**, 0 union-typed parameters, 734 tests passing

## Test plan

- [x] All 734 tests pass
- [x] Lint and format checks pass
- [x] Union type count verified at 0 across all tool categories
- [ ] Run diagnostic script on Pi to confirm API returns `OK: end_turn` instead of 400
- [ ] Verify bot responds to messages in Telegram after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)