### PR TITLE
Fix Tradera AddItem: always include ItemAttributes in SOAP request

### DIFF
--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -237,8 +237,7 @@ class TraderaClient:
             if shipping_condition is not None:
                 params["ShippingCondition"] = shipping_condition
 
-            if item_attributes:
-                params["ItemAttributes"] = item_attributes
+            params["ItemAttributes"] = item_attributes or []
             if attribute_values:
                 for av in attribute_values:
                     if "id" not in av or "values" not in av:

--- a/tests/test_tradera.py
+++ b/tests/test_tradera.py
@@ -480,7 +480,7 @@ class TestCreateListingAttributes:
 
         call_kwargs = client._restricted_client.service.AddItem.call_args.kwargs
         item_req = call_kwargs["itemRequest"]
-        assert "ItemAttributes" not in item_req
+        assert item_req["ItemAttributes"] == []
         assert "AttributeValues" not in item_req
 
     def test_rejects_attribute_missing_id(self, client):


### PR DESCRIPTION
## Summary
- Tradera's `AddItem` API requires the `ItemAttributes` XML element to always be present in the SOAP request, even when empty
- The previous code (`if item_attributes:`) only included it when non-empty, causing a SOAP 500 fault: `"ItemAttributes are missing"` on publish
- Fix: `params["ItemAttributes"] = item_attributes or []` — always sends the element

## Root cause
`GetAttributeDefinitions` for category 332241 (wallpaper) correctly returned empty — no category-specific attributes. But the code then omitted `ItemAttributes` entirely from the `AddItem` request, and Tradera rejected it.

## Test plan
- [x] Existing test updated to expect `[]` instead of key absence
- [x] Full test suite passes (748 tests)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)