### PR TITLE
Fix approve_draft blocking when category has no attributes

### DIFF
--- a/src/storebot/tools/listing.py
+++ b/src/storebot/tools/listing.py
@@ -219,7 +219,7 @@ class ListingService:
                 return {"error": f"Cannot approve listing with status '{listing.status}'"}
 
             details = listing.details or {}
-            if listing.tradera_category_id and not details.get("attribute_values"):
+            if listing.tradera_category_id and details.get("attribute_values") is None:
                 return {
                     "success": False,
                     "warning": "Inga kategoriattribut har angetts. Använd get_attribute_definitions "

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -303,6 +303,23 @@ class TestApproveDraft:
         assert "kategoriattribut" in result["warning"]
         assert result["status"] == "draft"
 
+    def test_no_warning_when_empty_attributes(self, service, product):
+        """Empty attribute_values means user checked and found none required."""
+        draft = service.create_draft(
+            product_id=product,
+            listing_type="auction",
+            listing_title="Test",
+            listing_description="Test",
+            start_price=100.0,
+            tradera_category_id=344,
+            details={"attribute_values": []},
+        )
+
+        result = service.approve_draft(draft["listing_id"])
+
+        assert "warning" not in result
+        assert result["status"] == "approved"
+
     def test_no_warning_when_attributes_present(self, service, product):
         draft = service.create_draft(
             product_id=product,


### PR DESCRIPTION
## Summary
- `approve_draft` validation used `not details.get("attribute_values")` which treats `[]` as falsy
- This blocked approval even when the bot explicitly set `attribute_values: []` after confirming the category has no required attributes via `get_attribute_definitions`
- Changed to `is None` check: absent key (not checked yet) → warns, empty list (checked, none needed) → allows approval

## Test plan
- [x] New test: `test_no_warning_when_empty_attributes` — empty `[]` passes approval
- [x] Existing test: `test_warns_when_no_attributes_set` — absent key still warns
- [x] Full test suite passes (749 tests)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)