### PR TITLE
Fix Tradera publish: ItemAttributes requires condition (Ny/Begagnad)

### DIFF
--- a/src/storebot/agent.py
+++ b/src/storebot/agent.py
@@ -159,14 +159,20 @@ VIKTIGT — Frakt vid annonsering:
 3. Alternativt: sätt details.shipping_cost för enkel fast fraktkostnad.
 4. Visa fraktalternativen i förhandsgranskningen så ägaren kan godkänna.
 
-VIKTIGT — Kategoriattribut vid annonsering:
+VIKTIGT — Attribut vid annonsering:
+
+Skick (item_attributes) — obligatoriskt på ALLA annonser:
+- Sätt details.item_attributes till [1] för Ny eller [2] för Begagnad.
+- Standard är [2] (Begagnad) om inget anges. Ändra till [1] för oanvända varor.
+
+Kategoriattribut (attribute_values) — varierar per kategori:
 1. INNAN du godkänner ett utkast, använd get_attribute_definitions med annonsens kategori-ID.
 2. Attribut med min_values > 0 är obligatoriska — Tradera avvisar annonser utan dem.
 3. Föreslå lämpliga attributvärden baserat på produktens egenskaper (material, tidsepok, skick etc.).
 4. Visa förslagen för ägaren och invänta godkännande.
 5. Uppdatera utkastet med update_draft_listing (lägg item_attributes och attribute_values i details) INNAN approve.
 6. Varje attribute_values-post: {id, name, values (lista med valda värden från possible_values)}.
-7. Godkänn INTE utkastet förrän obligatoriska attribut är ifyllda.
+7. Om get_attribute_definitions returnerar tom lista, sätt attribute_values till [] och godkänn.
 
 Om du behöver verktyg som inte är tillgängliga, använd request_tools för att begära fler.
 

--- a/src/storebot/tools/listing.py
+++ b/src/storebot/tools/listing.py
@@ -367,7 +367,9 @@ class ListingService:
         shipping_condition = details.get("shipping_condition")
         shipping_cost = None if shipping_options else details.get("shipping_cost")
         reserve_price = details.get("reserve_price") if listing.listing_type == "auction" else None
-        item_attributes = details.get("item_attributes")
+        # ItemAttributes = global condition flags (1=Ny, 2=Begagnad), required by Tradera.
+        # Default to [2] (Begagnad) since this shop primarily sells second-hand items.
+        item_attributes = details.get("item_attributes") or [2]
         attribute_values = details.get("attribute_values")
 
         create_result = self.tradera.create_listing(

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -1210,7 +1210,7 @@ class TestPublishListing:
         pub_service.publish_listing(listing_id)
 
         call_kwargs = pub_service.tradera.create_listing.call_args.kwargs
-        assert call_kwargs.get("item_attributes") is None
+        assert call_kwargs["item_attributes"] == [2]  # default: Begagnad
         assert call_kwargs.get("attribute_values") is None
 
 


### PR DESCRIPTION
## Summary
- Tradera's `ItemAttributes` is a **global item condition field** (not category-specific), requiring `[1]` (Ny/New) or `[2]` (Begagnad/Used)
- An empty array `[]` is rejected the same as a missing element — Tradera needs at least one valid condition ID
- `GetAttributeDefinitions` returns *category-specific* attributes (material, era, etc.) — a completely separate concept
- Default `item_attributes` to `[2]` (Begagnad) in `_create_tradera_listing` since this shop primarily sells second-hand items
- Updated system prompt to clearly distinguish `item_attributes` (condition) from `attribute_values` (category-specific)
- Added guidance for agent to set `attribute_values: []` when category has no definitions

## Changes
- `listing.py`: `_create_tradera_listing` defaults `item_attributes` to `[2]` via `or [2]`
- `agent.py`: System prompt explains the two attribute types and valid values
- `test_listing.py`: Updated test to expect `[2]` default instead of `None`

## Test plan
- [x] Full test suite passes (749 tests)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)