### PR TITLE
Fix ShippingOptions SOAP serialization for AddItem

### DIFF
--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -228,11 +228,11 @@ class TraderaClient:
             if buy_it_now_price is not None:
                 params["BuyItNowPrice"] = int(buy_it_now_price)
             if shipping_options:
-                params["ShippingOptions"] = [
-                    self._build_shipping_option(opt) for opt in shipping_options
-                ]
+                params["ShippingOptions"] = {
+                    "ItemShipping": [self._build_shipping_option(opt) for opt in shipping_options]
+                }
             elif shipping_cost is not None:
-                params["ShippingOptions"] = [{"Cost": int(shipping_cost)}]
+                params["ShippingOptions"] = {"ItemShipping": [{"Cost": int(shipping_cost)}]}
 
             if shipping_condition is not None:
                 params["ShippingCondition"] = shipping_condition

--- a/tests/test_tradera.py
+++ b/tests/test_tradera.py
@@ -376,7 +376,7 @@ class TestTraderaCreateListing:
         call_kwargs = client._restricted_client.service.AddItem.call_args.kwargs
         item_req = call_kwargs["itemRequest"]
         assert "ShippingCost" not in item_req
-        assert item_req["ShippingOptions"] == [{"Cost": 99}]
+        assert item_req["ShippingOptions"] == {"ItemShipping": [{"Cost": 99}]}
 
     def test_auto_commit_false(self, client):
         response = MagicMock()
@@ -878,7 +878,7 @@ class TestCreateListingShipping:
         assert "ShippingOptions" in item_req
         assert "ShippingCost" not in item_req
         assert item_req["ShippingCondition"] == "PostBefordran"
-        soap_opt = item_req["ShippingOptions"][0]
+        soap_opt = item_req["ShippingOptions"]["ItemShipping"][0]
         assert soap_opt["Cost"] == 59
         assert soap_opt["ShippingProductId"] == 10
         assert soap_opt["ShippingProviderId"] == 1
@@ -919,7 +919,7 @@ class TestCreateListingShipping:
         call_kwargs = client._restricted_client.service.AddItem.call_args.kwargs
         item_req = call_kwargs["itemRequest"]
         assert "ShippingCost" not in item_req
-        assert item_req["ShippingOptions"] == [{"Cost": 49}]
+        assert item_req["ShippingOptions"] == {"ItemShipping": [{"Cost": 49}]}
 
 
 class TestTraderaLeaveFeedback:


### PR DESCRIPTION
## Summary

- Wrap shipping options in `{"ItemShipping": [...]}` to match the `ArrayOfItemShipping` WSDL type
- Zeep was passing dict keys (`Cost`, `ShippingProviderId`) as kwargs to `ArrayOfItemShipping()` instead of creating `ItemShipping` child elements
- Fixes both flat `shipping_cost` and structured `shipping_options` paths

## Root cause

The Tradera WSDL defines:
```xml
<complexType name="ArrayOfItemShipping">
  <sequence>
    <element name="ItemShipping" type="tns:ItemShipping" maxOccurs="unbounded"/>
  </sequence>
</complexType>
```

We were passing `[{"Cost": 99}]` but zeep needs `{"ItemShipping": [{"Cost": 99}]}`.

## Test plan

- [x] 758 tests passing
- [x] Lint and format clean
- [ ] Deploy and verify publishing with shipping options works on Tradera

🤖 Generated with [Claude Code](https://claude.com/claude-code)