### PR TITLE
Fix get_shipping_options parsing: wrong WSDL field names

### DIFF
--- a/src/storebot/tools/definitions.py
+++ b/src/storebot/tools/definitions.py
@@ -137,7 +137,7 @@ TOOLS = [
     },
     {
         "name": "get_shipping_options",
-        "description": "Hämta tillgängliga fraktalternativ från Tradera. Returnerar fraktprodukter med leverantör, viktgräns och pris. Använd produktens vikt för att filtrera.",
+        "description": "Hämta tillgängliga fraktalternativ från Tradera. Returnerar en lista med fälten shipping_product_id, shipping_provider_id, cost, name m.fl. — skicka valda alternativ direkt till shipping_options i update_draft_listing. Använd produktens vikt för att filtrera.",
         "category": "listing",
         "input_schema": {
             "type": "object",


### PR DESCRIPTION
## Summary
- Fixed `get_shipping_options` response parsing — it was returning empty `[]` because it used wrong zeep attribute names (`ShippingOptionsPerWeightSpan` instead of `ProductsPerWeightSpan`, `ShippingProduct` instead of `Product`)
- Fixed `_parse_shipping_product` to use actual WSDL field names (`ShippingProvider`, `ShippingProviderId`, `Price`, `VatPercent`, `FromCountry`, `ToCountry`, nested `PackageRequirements` and `DeliveryInformation`)
- Aligned output field names (`cost`, `shipping_product_id`, `shipping_provider_id`) to match `_build_shipping_option` input so the agent can pass options directly to listing details
- Weight converted from decimal kg (WSDL format) to grams
- Updated tool description to guide the agent on direct field mapping

## Test plan
- [x] All 759 tests pass
- [x] Lint + format clean
- [x] New test: weight filtering with grams conversion
- [ ] Deploy to Pi and verify publish_listing end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)