### PR TITLE
Fix Alembic fileConfig silencing all storebot loggers

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,7 +9,7 @@ from storebot.db import Base
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = Base.metadata
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -3,6 +3,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 
 from storebot.logging_config import JSONFormatter, configure_logging
+from storebot.db import init_db
 
 
 class TestJSONFormatter:
@@ -168,3 +169,17 @@ class TestConfigureLogging:
 
         assert len(root.handlers) == 1
         assert not isinstance(root.handlers[0], RotatingFileHandler)
+
+    def test_storebot_loggers_not_disabled_after_init_db(self):
+        """Alembic fileConfig must not disable existing storebot loggers."""
+        # Ensure storebot loggers exist before init_db
+        test_logger = logging.getLogger("storebot.test_check")
+        test_logger.info("pre-init")
+
+        init_db()
+        configure_logging(level="INFO", json_format=True)
+
+        assert not test_logger.disabled, (
+            "storebot logger disabled by Alembic fileConfig — "
+            "check disable_existing_loggers=False in alembic/env.py"
+        )


### PR DESCRIPTION
## Summary
- Alembic's `fileConfig()` in `env.py` was called without `disable_existing_loggers=False`, which disabled every `storebot.*` logger since they were created at import time before `init_db()` runs
- This caused **zero** application-level log output — only third-party httpcore/zeep DEBUG traffic appeared, making errors completely invisible
- Added regression test that verifies storebot loggers remain enabled after `init_db()`

## Test plan
- [x] 760 tests pass
- [x] Lint clean
- [x] New test: `test_storebot_loggers_not_disabled_after_init_db`
- [ ] Deploy to Pi and verify storebot INFO/ERROR entries appear in log

🤖 Generated with [Claude Code](https://claude.com/claude-code)