### PR TITLE
Fix GetCategories SOAP response parsing (0 categories synced)

### DIFF
--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -391,10 +391,9 @@ class TraderaClient:
                 }
             )
             children = getattr(cat, "Category", None) or []
-            if children:
-                if not isinstance(children, list):
-                    children = [children]
-                result.extend(TraderaClient._flatten_categories(children, cat_id, path, depth + 1))
+            if not isinstance(children, list):
+                children = [children]
+            result.extend(TraderaClient._flatten_categories(children, cat_id, path, depth + 1))
         return result
 
     @retry_on_transient()
@@ -406,7 +405,7 @@ class TraderaClient:
         try:
             response = self._get_categories_api_call(self._auth_headers(self.public_client))
 
-            raw_cats = self._soap_list(getattr(response, "Categories", None), "Category")
+            raw_cats = self._soap_list(response, "Category")
 
             return {
                 "categories": self._flatten_categories(raw_cats),

--- a/tests/test_tradera.py
+++ b/tests/test_tradera.py
@@ -601,9 +601,7 @@ class TestTraderaGetCategories:
         cat2.Category = None
 
         response = MagicMock()
-        cats_obj = MagicMock()
-        cats_obj.Category = [cat1, cat2]
-        response.Categories = cats_obj
+        response.Category = [cat1, cat2]
         client._public_client.service.GetCategories.return_value = response
 
         result = client.get_categories()
@@ -627,9 +625,7 @@ class TestTraderaGetCategories:
 
     def test_empty_categories(self, client):
         response = MagicMock()
-        cats_obj = MagicMock()
-        cats_obj.Category = []
-        response.Categories = cats_obj
+        response.Category = []
         client._public_client.service.GetCategories.return_value = response
 
         result = client.get_categories()
@@ -1215,9 +1211,7 @@ class TestSyncCategoriesToDb:
         parent.Category = [child]
 
         response = MagicMock()
-        cats_container = MagicMock()
-        cats_container.Category = [parent]
-        response.Categories = cats_container
+        response.Category = [parent]
         client._public_client.service.GetCategories.return_value = response
 
         count = client.sync_categories_to_db(engine)
@@ -1257,9 +1251,7 @@ class TestSyncCategoriesToDb:
         parent.Category = None
 
         response = MagicMock()
-        cats_container = MagicMock()
-        cats_container.Category = [parent]
-        response.Categories = cats_container
+        response.Category = [parent]
         client._public_client.service.GetCategories.return_value = response
 
         count = client.sync_categories_to_db(engine)
@@ -1296,9 +1288,7 @@ class TestSyncCategoriesToDb:
         parent.Category = None
 
         response = MagicMock()
-        cats_container = MagicMock()
-        cats_container.Category = [parent]
-        response.Categories = cats_container
+        response.Category = [parent]
         client._public_client.service.GetCategories.return_value = response
 
         client.sync_categories_to_db(engine)


### PR DESCRIPTION
## Summary

- Fixed `get_categories()` returning 0 categories: zeep unwraps `GetCategoriesResult` and returns `ArrayOfCategory` directly, so the category list lives at `response.Category` — not `response.Categories.Category` as the code assumed
- Removed a redundant `if children:` guard in `_flatten_categories` — `extend([])` is a no-op so the outer check was dead code
- Updated all five affected test mocks to match the correct response structure

## Test plan

- [ ] All 799 existing tests pass
- [ ] `storebot-sync-categories` now populates the `tradera_categories` table correctly on the Pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)