### PR TITLE
fix: cast zeep enum types to str in SOAP response parsers

### DIFF
--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -130,6 +130,10 @@ class TraderaClient:
         if end_date is not None:
             end_date = str(end_date)
 
+        item_type = getattr(item, "ItemType", None)
+        if item_type is not None:
+            item_type = str(item_type)
+
         return {
             "id": item.Id,
             "title": item.ShortDescription,
@@ -139,7 +143,7 @@ class TraderaClient:
             "image_url": image_url,
             "end_date": end_date,
             "seller": getattr(item, "SellerAlias", None),
-            "item_type": getattr(item, "ItemType", None),
+            "item_type": item_type,
         }
 
     @retry_on_transient()
@@ -757,6 +761,10 @@ class TraderaClient:
             if end_date is not None:
                 end_date = str(end_date)
 
+            status = getattr(response, "Status", None)
+            if status is not None:
+                status = str(status)
+
             return {
                 "id": getattr(response, "Id", item_id),
                 "title": getattr(response, "Title", None),
@@ -764,7 +772,7 @@ class TraderaClient:
                 "price": float(
                     getattr(response, "BuyItNowPrice", 0) or getattr(response, "MaxBid", 0) or 0
                 ),
-                "status": getattr(response, "Status", None),
+                "status": status,
                 "end_date": end_date,
                 "url": getattr(response, "ItemUrl", None),
                 "views": getattr(response, "TotalViews", 0) or 0,


### PR DESCRIPTION
## Summary

- Zeep deserializes SOAP enum fields (`ItemStatus`, `ItemType`) as custom Python objects, not plain strings
- `agent.py:_json_default` only handles `Decimal`, causing `TypeError: Object of type ItemStatus is not JSON serializable` on `get_tradera_item` calls in production
- Cast `Status` in `get_item()` and `ItemType` in `_parse_item()` to `str()`, matching the existing `end_date` conversion pattern
- Added 2 regression tests with non-serializable mock enum objects + `json.dumps()` assertion

## Test plan

- [x] New tests `test_status_enum_is_serializable` and `test_item_type_enum_is_serializable` pass
- [x] Full suite: 810 tests passing
- [x] Lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)