### PR TITLE
fix: use uv run for semantic-release in CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Semantic Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release version --commit --tag --push --changelog
+        run: uv run semantic-release version --commit --tag --push --changelog


### PR DESCRIPTION
## Summary
- The release workflow installed `python-semantic-release` via `uv pip install` but ran the binary without `uv run`, causing `command not found` (exit code 127)
- Added `uv run` prefix to the `semantic-release version` command

## Test plan
- [ ] Merge this PR and verify the release workflow passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)