### PR TITLE
docs: emphasize Tradera as the selling platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Storebot is an AI-powered agent system for managing a Swedish country shop ("Lantshop") that sells renovated furniture, décor, curiosities, antiques, and crops. The owner interacts with the system primarily through a Telegram bot. Planned launch: November 2026.
+Storebot is an AI-powered agent system for selling goods on Swedish marketplaces. The owner interacts with the system through a Telegram bot backed by Claude. It handles the full lifecycle: sourcing, pricing, listing, order management, shipping, and bookkeeping.
 
 ## Tech Stack
 
@@ -105,20 +105,13 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 - **Semantic versioning** — Conventional commits with `python-semantic-release`. Version in `src/storebot/__init__.py` (single source of truth), automatic bumps via GitHub Actions on merge to main. Pre-commit hook validates commit message format.
 - **Tests** — 857 tests across 27 modules covering db, tradera, blocket, pricing, listing, image, order, accounting, conversation, scout, marketing, analytics, postnord, CLI, retry, logging, handlers, formatting, log_viewer, compaction, model_routing, parallel, reflection, schemas, thinking, tool_filtering, and usage.
 
-### Not started
+### Roadmap
 
-- MCP server wrappers for tool modules
 - sqlite-vec embeddings for semantic product search
-- Social media cross-posting
-- Customer message handling (requires email/IMAP — Tradera API has no messaging support)
-- Crop management, custom webshop, wishlist matching
-
-## Build Phases
-
-1. **Phase 1 (MVP):** SQLite schema + SQLAlchemy ORM, Tradera/Blocket search tools, Pricing Agent, Listing Agent — **DONE**
-2. **Phase 2:** Telegram bot, Order Agent, local voucher/PDF export — **DONE**
-3. **Phase 3:** Scout Agent (scheduled) — **DONE**, Marketing Agent — **DONE**, Analytics — **DONE**, MCP server wrappers, social media cross-posting
-4. **Phase 4:** Crop management, custom webshop, wishlist matching
+- MCP server wrappers for tool modules
+- Social media cross-posting (Instagram, Facebook Marketplace)
+- Customer message handling (email/IMAP — Tradera API has no messaging support)
+- Custom webshop, wishlist matching
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Storebot
 
-**Your AI-powered business partner for selling on Swedish marketplaces.**
+**Your AI-powered business partner for selling on Tradera.**
 
-Storebot is an autonomous agent system that handles the entire lifecycle of buying and selling goods online — from sourcing and pricing to listing, order management, shipping, and bookkeeping. You interact with it through Telegram, and it takes care of the rest.
+Storebot is an autonomous agent system that handles the entire lifecycle of selling goods on [Tradera](https://www.tradera.com) — from sourcing and pricing to listing, order management, shipping, and bookkeeping. It also searches Blocket for market research and sourcing leads, but all selling happens through Tradera. You interact with it through Telegram, and it takes care of the rest.
 
 Whether you sell vintage furniture, electronics, clothing, collectibles, or anything in between — Storebot manages the tedious parts so you can focus on finding great items.
 
@@ -15,7 +15,7 @@ Whether you sell vintage furniture, electronics, clothing, collectibles, or anyt
 | Capability | What happens |
 |---|---|
 | **Product Listing** | Vision-based item description, Swedish title/description generation, Tradera category selection, image optimization and upload |
-| **Pricing Intelligence** | Cross-platform price research on Tradera and Blocket, statistical analysis (min/max/mean/median), quartile-based price suggestions |
+| **Pricing Intelligence** | Cross-platform price research on Tradera and Blocket (read-only), statistical analysis (min/max/mean/median), quartile-based price suggestions |
 | **Order Management** | Automatic Tradera order polling, inventory updates, PostNord shipping label generation, shipment tracking |
 | **Bookkeeping** | Double-entry vouchers following BAS-kontoplan, automatic VAT calculation, PDF export for your accountant |
 | **Sourcing (Scout)** | Saved searches with daily digest notifications, deduplication of already-seen items, find deals before anyone else |
@@ -30,8 +30,8 @@ You (Telegram)
   ▼
 Claude API ─── tool use + vision ─── Agent Loop
   │
-  ├── Tradera (SOAP)      search, list, sell, categories
-  ├── Blocket (REST)       price research, sourcing
+  ├── Tradera (SOAP)      search, list, sell, ship, categories
+  ├── Blocket (REST)       price research, sourcing (read-only)
   ├── Accounting           vouchers, VAT, PDF export
   ├── Scout                saved searches, daily digests
   ├── Marketing            performance tracking, recommendations
@@ -67,6 +67,13 @@ SQLite ── single file, zero maintenance
 
 Beyond commands, Storebot understands natural language in Swedish and English. Send text, photos, or voice your requests — the agent figures out which tools to use.
 
+## Prerequisites
+
+- **Tradera API access** — Register at the [Tradera Developer Program](https://api.tradera.com) and contact Tradera (`apiadmin@tradera.com`) to enable API access for your account. This is required for all listing and selling functionality. You will also need to request access to the `RestrictedService` and `OrderService` for full write operations.
+- **Claude API key** — For the AI agent ([console.anthropic.com](https://console.anthropic.com))
+- **Telegram Bot Token** — Create a bot via [@BotFather](https://t.me/BotFather)
+- **PostNord API key** (optional) — For shipping label generation
+
 ## Quick Start
 
 ```bash
@@ -77,7 +84,7 @@ cp .env.example .env   # fill in API keys
 storebot               # start the bot
 ```
 
-You'll need API keys for Claude, Telegram, and Tradera. See the [Installation Guide](docs/installation.md) for the full setup walkthrough.
+See the [Installation Guide](docs/installation.md) for the full setup walkthrough.
 
 ## Tech Stack
 
@@ -87,7 +94,7 @@ You'll need API keys for Claude, Telegram, and Tradera. See the [Installation Gu
 | LLM | Claude API (direct tool use, no framework overhead) |
 | Database | SQLite + sqlite-vec (zero-maintenance, single-file) |
 | Chat | Telegram via python-telegram-bot v20+ |
-| Marketplaces | Tradera (SOAP/zeep), Blocket (REST) |
+| Marketplace | Tradera (SOAP/zeep) — selling; Blocket (REST) — research only |
 | Shipping | PostNord REST API |
 | ORM | SQLAlchemy 2.0 + Alembic migrations |
 | Accounting | Local double-entry bookkeeping, PDF via ReportLab |


### PR DESCRIPTION
## Summary
- Clarify that Storebot sells exclusively on Tradera, with Blocket used only for market research and sourcing
- Add a **Prerequisites** section to README with Tradera API registration details and `apiadmin@tradera.com` contact
- Mark Blocket as "(read-only)" throughout (capabilities table, architecture diagram, tech stack)
- Simplify CLAUDE.md: update project overview, consolidate roadmap section

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all links (Tradera, Anthropic console, BotFather) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)