### PR TITLE
chore: remove sqlite-vec dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Storebot is an AI-powered agent system for selling goods on Swedish marketplaces
 
 - **Language:** Python 3.11+
 - **LLM:** Claude API (direct integration, no LangChain)
-- **Database:** SQLite + sqlite-vec (single-user, simple deployment)
+- **Database:** SQLite (single-user, simple deployment)
 - **Accounting:** Local SQLite vouchers + PDF export (double-entry bookkeeping, BAS-kontoplan)
 - **Chat interface:** Telegram via `python-telegram-bot` v20+
 - **Marketplace APIs:** Tradera (SOAP via `zeep`), Blocket (unofficial REST, no auth needed)
@@ -35,7 +35,7 @@ Agent Tool Modules (plain Python, MCP-wrappable later)
     ├── tools/conversation.py(history persistence per chat)
     └── tools/image.py       (Pillow: resize, optimize)
     ↓
-SQLite + sqlite-vec (operational + financial: inventory, listings, orders, vouchers, agent state, embeddings)
+SQLite (operational + financial: inventory, listings, orders, vouchers, agent state)
 ```
 
 ### Sub-Agents
@@ -108,7 +108,6 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 
 ### Roadmap
 
-- sqlite-vec embeddings for semantic product search
 - Social media cross-posting (Instagram, Facebook Marketplace)
 - Customer message handling (email/IMAP — Tradera API has no messaging support)
 - Custom webshop, wishlist matching

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See the [Installation Guide](docs/installation.md) for the full setup walkthroug
 |---|---|
 | Language | Python 3.13 |
 | LLM | Claude API (direct tool use, no framework overhead) |
-| Database | SQLite + sqlite-vec (zero-maintenance, single-file) |
+| Database | SQLite (zero-maintenance, single-file) |
 | Chat | Telegram via python-telegram-bot v20+ |
 | Marketplace | Tradera (SOAP/zeep) — selling; Blocket (REST) — research only |
 | Shipping | PostNord REST API |
@@ -121,8 +121,6 @@ The core system is fully operational: listing, pricing, orders, shipping, accoun
 
 ### Roadmap
 
-- **Semantic search** — sqlite-vec embeddings for finding similar products in your inventory
-- **MCP server wrappers** — Expose tool modules as MCP servers for use with other AI clients
 - **Social media cross-posting** — Publish listings to Instagram, Facebook Marketplace, etc.
 - **Customer messaging** — Email/IMAP integration for handling buyer questions
 - **Custom webshop** — Standalone storefront beyond marketplace platforms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "zeep>=4.2,<5.0",
     "requests>=2.31,<3.0",
     "sqlalchemy>=2.0,<3.0",
-    "sqlite-vec",
     "pillow>=12.1.1,<13.0",
     "reportlab>=4.0,<5.0",
     "pydantic-settings>=2.0,<3.0",

--- a/src/storebot/db.py
+++ b/src/storebot/db.py
@@ -266,22 +266,6 @@ def _configure_sqlite(dbapi_connection, connection_record):
     cursor.close()
 
 
-def _load_sqlite_vec(dbapi_connection, connection_record):
-    enabled = False
-    try:
-        import sqlite_vec
-
-        dbapi_connection.enable_load_extension(True)
-        enabled = True
-        sqlite_vec.load(dbapi_connection)
-        logger.debug("sqlite_vec extension loaded")
-    except Exception as e:
-        logger.debug("sqlite_vec not loaded (optional): %s", e)
-    finally:
-        if enabled:
-            dbapi_connection.enable_load_extension(False)
-
-
 def _secure_db_file(database_path: str) -> None:
     db_path = Path(database_path)
     if db_path.exists():
@@ -299,7 +283,6 @@ def create_engine(database_path: str | None = None) -> sa.Engine:
 
     engine = sa.create_engine(f"sqlite:///{database_path}")
     event.listen(engine, "connect", _configure_sqlite)
-    event.listen(engine, "connect", _load_sqlite_vec)
 
     return engine
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,3 @@
-import logging
-
 import sqlalchemy as sa
 
 from storebot.db import (
@@ -180,23 +178,6 @@ def test_tradera_category_model(session):
     assert result.depth == 2
     assert result.parent_tradera_id == 100
     assert result.description is not None
-
-
-def test_load_sqlite_vec_failure(tmp_path, caplog):
-    """Cover _load_sqlite_vec exception path (lines 278-279)."""
-    import sqlite_vec
-    from unittest.mock import patch
-
-    db_path = str(tmp_path / "test_vec_fail.db")
-    with (
-        patch.object(sqlite_vec, "load", side_effect=Exception("vec not found")),
-        caplog.at_level(logging.DEBUG, logger="storebot.db"),
-    ):
-        eng = create_engine(database_path=db_path)
-        # Engine should still work despite sqlite_vec failing
-        tables = sa.inspect(eng).get_table_names()
-        assert isinstance(tables, list)
-    assert "sqlite_vec not loaded (optional): vec not found" in caplog.text
 
 
 def test_secure_db_file_oserror(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1692,18 +1692,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sqlite-vec"
-version = "0.1.6"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ed/aabc328f29ee6814033d008ec43e44f2c595447d9cccd5f2aabe60df2933/sqlite_vec-0.1.6-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:77491bcaa6d496f2acb5cc0d0ff0b8964434f141523c121e313f9a7d8088dee3", size = 164075, upload-time = "2024-11-20T16:40:29.847Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/57/05604e509a129b22e303758bfa062c19afb020557d5e19b008c64016704e/sqlite_vec-0.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fdca35f7ee3243668a055255d4dee4dea7eed5a06da8cad409f89facf4595361", size = 165242, upload-time = "2024-11-20T16:40:31.206Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/48/dbb2cc4e5bad88c89c7bb296e2d0a8df58aab9edc75853728c361eefc24f/sqlite_vec-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b0519d9cd96164cd2e08e8eed225197f9cd2f0be82cb04567692a0a4be02da3", size = 103704, upload-time = "2024-11-20T16:40:33.729Z" },
-    { url = "https://files.pythonhosted.org/packages/80/76/97f33b1a2446f6ae55e59b33869bed4eafaf59b7f4c662c8d9491b6a714a/sqlite_vec-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:823b0493add80d7fe82ab0fe25df7c0703f4752941aee1c7b2b02cec9656cb24", size = 151556, upload-time = "2024-11-20T16:40:35.387Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/98/e8bc58b178266eae2fcf4c9c7a8303a8d41164d781b32d71097924a6bebe/sqlite_vec-0.1.6-py3-none-win_amd64.whl", hash = "sha256:c65bcfd90fa2f41f9000052bcb8bb75d38240b2dae49225389eca6c3136d3f0c", size = 281540, upload-time = "2024-11-20T16:40:37.296Z" },
-]
-
-[[package]]
 name = "sse-starlette"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1743,7 +1731,6 @@ dependencies = [
     { name = "reportlab" },
     { name = "requests" },
     { name = "sqlalchemy" },
-    { name = "sqlite-vec" },
     { name = "textual" },
     { name = "zeep" },
 ]
@@ -1774,7 +1761,6 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31,<3.0" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sqlalchemy", specifier = ">=2.0,<3.0" },
-    { name = "sqlite-vec" },
     { name = "textual", specifier = ">=0.89" },
     { name = "zeep", specifier = ">=4.2,<5.0" },
 ]


### PR DESCRIPTION
## Summary
- Remove `sqlite-vec` from `pyproject.toml` dependencies and regenerate `uv.lock`
- Delete `_load_sqlite_vec` connection hook from `db.py` and its event listener registration
- Remove `test_load_sqlite_vec_failure` test and unused `logging` import from `test_db.py`
- Clean up all sqlite-vec / embeddings references from `CLAUDE.md` and `README.md` roadmaps
- Also remove "MCP server wrappers" from `README.md` roadmap since it was implemented in PR #119

## Test plan
- [x] 1073 tests passing (1 test removed)
- [x] 99.03% coverage (above 99% threshold)
- [x] Lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)