### PR TITLE
fix: use PAT for semantic-release to bypass branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # NOTE: If branch protection requires PR reviews on main,
-          # replace with a fine-grained PAT stored as secrets.SEMANTIC_RELEASE_TOKEN
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - uses: astral-sh/setup-uv@v7
         with:
@@ -38,5 +36,5 @@ jobs:
 
       - name: Semantic Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         run: uv run semantic-release version --commit --tag --push --changelog


### PR DESCRIPTION
## Summary
- Release workflow fails because `GITHUB_TOKEN` cannot push directly to `main` when branch protection requires pull requests (GH013 error)
- Switch to a fine-grained PAT (`SEMANTIC_RELEASE_TOKEN`) for both `actions/checkout` (git push) and the `GH_TOKEN` env var (GitHub release creation)

## Required manual step
After merging, add a **fine-grained PAT** as a repository secret named `SEMANTIC_RELEASE_TOKEN`:
1. Create PAT at GitHub → Settings → Developer settings → Fine-grained tokens, scoped to `dpalmqvist/storebot` with **Contents: Read and write**
2. Add as repo secret at Settings → Secrets and variables → Actions

## Test plan
- [ ] Create `SEMANTIC_RELEASE_TOKEN` secret with a fine-grained PAT
- [ ] Merge a `feat:` or `fix:` commit to main and verify the Release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)