### PR TITLE
feat: add proactive repricing and Tradera live listing management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Agent Tool Modules (plain Python, MCP-wrappable later)
     ├── tools/analytics.py   (business reports, profitability, ROI)
     ├── tools/scout.py       (saved searches, dedup, digest)
     ├── tools/marketing.py   (listing performance, recommendations)
+    ├── tools/repricing.py   (proactive price proposals, approval workflow)
     ├── tools/postnord.py    (shipping labels)
     ├── tools/conversation.py(history persistence per chat)
     └── tools/image.py       (Pillow: resize, optimize)
@@ -57,7 +58,7 @@ SQLite (operational + financial: inventory, listings, orders, vouchers, agent st
 
 ## Database Schema (Core Tables)
 
-`products`, `product_images`, `platform_listings`, `listing_snapshots`, `orders`, `vouchers`, `voucher_rows`, `agent_actions`, `notifications`, `conversation_messages`, `saved_searches`, `seen_items`
+`products`, `product_images`, `platform_listings`, `listing_snapshots`, `orders`, `vouchers`, `voucher_rows`, `agent_actions`, `notifications`, `conversation_messages`, `saved_searches`, `seen_items`, `price_proposals`
 
 SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Alembic migrations (SQLite batch mode).
 
@@ -87,7 +88,7 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 - **Product management** — `create_product` (with all optional fields: condition, materials, era, dimensions, source, acquisition_cost, weight_grams), `get_product` (full detail lookup with image/listing counts), `save_product_image` (with is_primary logic), and `delete_product_image` (with automatic primary promotion).
 - **Image processing** — `resize_for_listing` (1200px), `resize_for_analysis` (800px), `optimize_for_upload` (JPEG compress), `encode_image_base64`. All handle EXIF rotation and RGBA conversion.
 - **Accounting** — `AccountingService` with local voucher storage (SQLite), double-entry bookkeeping with BAS-kontoplan, PDF export (single + batch), debit/credit balance validation, `list_vouchers` (with date filtering).
-- **Agent loop** — `agent.py` with Claude API tool loop, 53 tool definitions, vision support (base64 image content blocks), Swedish system prompt with image workflow guidance.
+- **Agent loop** — `agent.py` with Claude API tool loop, 63 tool definitions, vision support (base64 image content blocks), Swedish system prompt with image workflow guidance.
 - **Telegram bot** — `handlers.py` with `/start`, `/help`, `/new`, `/orders`, `/scout`, `/marketing`, `/rapport`, text message handling, and photo handling (download, resize, forward to agent with vision). HTML formatting via `bot/formatting.py` — agent Markdown responses converted to Telegram HTML, service reports HTML-escaped, `BadRequest` fallback to plain text.
 - **Config** — Pydantic Settings from `.env`, all service credentials.
 - **Deployment** — systemd service file, SQLite backup script with cron rotation.
@@ -103,8 +104,10 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 - **PostNord shipping labels** — `PostNordClient` REST client: `create_shipment()`, `get_label()`, `save_label()`. `Address` dataclass for sender/recipient, `parse_buyer_address()` for parsing Swedish addresses. Sandbox/production URL switching. Integrated into `OrderService.create_shipping_label()` with validation (weight, address), PDF label storage, tracking number persistence, and `AgentAction` audit trail.
 - **Resilience & observability** — Retry decorator with exponential backoff on transient errors (Tradera SOAP, Blocket REST, PostNord REST), structured JSON logging (`LOG_JSON` toggle), startup credential validation, admin alerts on scheduled job failures. SQLite WAL mode + busy timeout. Systemd restart limits, backup integrity checks with gzip compression.
 - **Semantic versioning** — Conventional commits with `python-semantic-release`. Version in `src/storebot/__init__.py` (single source of truth), automatic bumps via GitHub Actions on merge to main. Pre-commit hook validates commit message format.
-- **MCP server** — `storebot-mcp` CLI exposing all 57 tools via MCP protocol. Low-level `Server` class with shared dispatch from `dispatch.py`. Supports stdio (default) and streamable-http transports. Client-compatible with Claude Desktop, Claude Code, Cursor, etc.
-- **Tests** — 1072 tests across 30 modules covering db, tradera, blocket, pricing, listing, image, order, accounting, conversation, scout, marketing, analytics, postnord, CLI, retry, logging, handlers, formatting, log_viewer, compaction, model_routing, parallel, reflection, schemas, thinking, tool_filtering, usage, agent, dispatch, and mcp_server. 100% line coverage, 99% branch coverage.
+- **Proactive repricing** — `RepricingService` generates price proposals from marketing recommendations, stores in `price_proposals` table for human approval, executes via Tradera SOAP. Daily scheduled job sends digest to Telegram.
+- **Tradera live listing management** — `TraderaClient.end_item()` (EndItem SOAP) and `set_prices()` (SetPricesOnNonShopItems/SetPriceOnShopItems). `ListingService.end_tradera_listing()` and `update_live_listing_price()` for DB+SOAP sync. `cancel_listing()` now attempts best-effort EndItem.
+- **MCP server** — `storebot-mcp` CLI exposing all 62 tools via MCP protocol. Low-level `Server` class with shared dispatch from `dispatch.py`. Supports stdio (default) and streamable-http transports. Client-compatible with Claude Desktop, Claude Code, Cursor, etc.
+- **Tests** — 1144 tests across 31 modules covering db, tradera, blocket, pricing, listing, image, order, accounting, conversation, scout, marketing, analytics, postnord, CLI, retry, logging, handlers, formatting, log_viewer, compaction, model_routing, parallel, reflection, schemas, thinking, tool_filtering, usage, agent, dispatch, mcp_server, and repricing. 100% line coverage, 99% branch coverage.
 
 ### Roadmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 - **Proactive repricing** — `RepricingService` generates price proposals from marketing recommendations, stores in `price_proposals` table for human approval, executes via Tradera SOAP. Daily scheduled job sends digest to Telegram.
 - **Tradera live listing management** — `TraderaClient.end_item()` (EndItem SOAP) and `set_prices()` (SetPricesOnNonShopItems/SetPriceOnShopItems). `ListingService.end_tradera_listing()` and `update_live_listing_price()` for DB+SOAP sync. `cancel_listing()` now attempts best-effort EndItem.
 - **MCP server** — `storebot-mcp` CLI exposing all 62 tools via MCP protocol. Low-level `Server` class with shared dispatch from `dispatch.py`. Supports stdio (default) and streamable-http transports. Client-compatible with Claude Desktop, Claude Code, Cursor, etc.
-- **Tests** — 1155 tests across 31 modules covering db, tradera, blocket, pricing, listing, image, order, accounting, conversation, scout, marketing, analytics, postnord, CLI, retry, logging, handlers, formatting, log_viewer, compaction, model_routing, parallel, reflection, schemas, thinking, tool_filtering, usage, agent, dispatch, mcp_server, and repricing. 100% line coverage, 99% branch coverage.
+- **Tests** — 1156 tests across 31 modules covering db, tradera, blocket, pricing, listing, image, order, accounting, conversation, scout, marketing, analytics, postnord, CLI, retry, logging, handlers, formatting, log_viewer, compaction, model_routing, parallel, reflection, schemas, thinking, tool_filtering, usage, agent, dispatch, mcp_server, and repricing. 100% line coverage, 99% branch coverage.
 
 ### Roadmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ SQLAlchemy 2.0 declarative models in `src/storebot/db.py`. Schema managed via Al
 - **Proactive repricing** — `RepricingService` generates price proposals from marketing recommendations, stores in `price_proposals` table for human approval, executes via Tradera SOAP. Daily scheduled job sends digest to Telegram.
 - **Tradera live listing management** — `TraderaClient.end_item()` (EndItem SOAP) and `set_prices()` (SetPricesOnNonShopItems/SetPriceOnShopItems). `ListingService.end_tradera_listing()` and `update_live_listing_price()` for DB+SOAP sync. `cancel_listing()` now attempts best-effort EndItem.
 - **MCP server** — `storebot-mcp` CLI exposing all 62 tools via MCP protocol. Low-level `Server` class with shared dispatch from `dispatch.py`. Supports stdio (default) and streamable-http transports. Client-compatible with Claude Desktop, Claude Code, Cursor, etc.
-- **Tests** — 1144 tests across 31 modules covering db, tradera, blocket, pricing, listing, image, order, accounting, conversation, scout, marketing, analytics, postnord, CLI, retry, logging, handlers, formatting, log_viewer, compaction, model_routing, parallel, reflection, schemas, thinking, tool_filtering, usage, agent, dispatch, mcp_server, and repricing. 100% line coverage, 99% branch coverage.
+- **Tests** — 1155 tests across 31 modules covering db, tradera, blocket, pricing, listing, image, order, accounting, conversation, scout, marketing, analytics, postnord, CLI, retry, logging, handlers, formatting, log_viewer, compaction, model_routing, parallel, reflection, schemas, thinking, tool_filtering, usage, agent, dispatch, mcp_server, and repricing. 100% line coverage, 99% branch coverage.
 
 ### Roadmap
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ See the [Installation Guide](docs/installation.md) for the full setup walkthroug
 The core system is fully operational: listing, pricing, orders, shipping, accounting, scouting, marketing, and analytics all work end-to-end.
 
 - 63 agent tools across 17 modules
-- 1155 tests passing
+- 1156 tests passing
 - 15 database tables
 - 7 Telegram commands
 - Full audit trail via `agent_actions` table

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ See the [Installation Guide](docs/installation.md) for the full setup walkthroug
 
 The core system is fully operational: listing, pricing, orders, shipping, accounting, scouting, marketing, and analytics all work end-to-end.
 
-- 57 agent tools across 15 modules
-- 857 tests passing
-- 14 database tables
+- 63 agent tools across 17 modules
+- 1155 tests passing
+- 15 database tables
 - 7 Telegram commands
 - Full audit trail via `agent_actions` table
 

--- a/alembic/versions/d7f3a1b2c4e5_add_price_proposals_table.py
+++ b/alembic/versions/d7f3a1b2c4e5_add_price_proposals_table.py
@@ -1,0 +1,48 @@
+"""add price_proposals table
+
+Revision ID: d7f3a1b2c4e5
+Revises: ba506cad3529
+Create Date: 2026-03-04 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd7f3a1b2c4e5'
+down_revision: Union[str, Sequence[str], None] = 'ba506cad3529'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('price_proposals',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('listing_id', sa.Integer(), nullable=False),
+    sa.Column('proposal_type', sa.String(), nullable=False),
+    sa.Column('current_price', sa.Float(), nullable=False),
+    sa.Column('suggested_price', sa.Float(), nullable=False),
+    sa.Column('reason', sa.Text(), nullable=False),
+    sa.Column('status', sa.String(), nullable=True),
+    sa.Column('created_at', sa.DateTime(), nullable=True),
+    sa.Column('decided_at', sa.DateTime(), nullable=True),
+    sa.Column('executed_at', sa.DateTime(), nullable=True),
+    sa.Column('execution_error', sa.Text(), nullable=True),
+    sa.Column('details', sa.JSON(), nullable=True),
+    sa.ForeignKeyConstraint(['listing_id'], ['platform_listings.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+    with op.batch_alter_table('price_proposals', schema=None) as batch_op:
+        batch_op.create_index('ix_price_proposals_listing_status', ['listing_id', 'status'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table('price_proposals', schema=None) as batch_op:
+        batch_op.drop_index('ix_price_proposals_listing_status')
+
+    op.drop_table('price_proposals')

--- a/alembic/versions/d7f3a1b2c4e5_add_price_proposals_table.py
+++ b/alembic/versions/d7f3a1b2c4e5_add_price_proposals_table.py
@@ -27,7 +27,7 @@ def upgrade() -> None:
     sa.Column('current_price', sa.Float(), nullable=False),
     sa.Column('suggested_price', sa.Float(), nullable=False),
     sa.Column('reason', sa.Text(), nullable=False),
-    sa.Column('status', sa.String(), nullable=True),
+    sa.Column('status', sa.String(), nullable=False, server_default='pending'),
     sa.Column('created_at', sa.DateTime(), nullable=True),
     sa.Column('decided_at', sa.DateTime(), nullable=True),
     sa.Column('executed_at', sa.DateTime(), nullable=True),

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,9 +20,9 @@ See [installation.md](installation.md) for full configuration reference.
 
 ```
 src/storebot/
-  agent.py             Claude API tool loop (57 tools, vision support)
+  agent.py             Claude API tool loop (63 tools, vision support)
   config.py            Pydantic Settings from .env
-  db.py                SQLAlchemy 2.0 models (SQLite, 14 tables)
+  db.py                SQLAlchemy 2.0 models (SQLite, 15 tables)
   cli.py               Tradera authorization CLI
   retry.py             Retry decorator with exponential backoff
   logging_config.py    JSON/human-readable logging config

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,18 +80,18 @@ Storebot includes local double-entry bookkeeping using the Swedish BAS-kontoplan
 
 ## Agent Tools
 
-The Claude agent has access to 57 tools organized by domain:
+The Claude agent has access to 63 tools organized by domain:
 
 | Domain | Count | Tools |
 |--------|-------|-------|
 | **Search** | 3 | `search_tradera`, `search_blocket`, `get_blocket_ad` |
 | **Products** | 9 | `create_product`, `update_product`, `get_product`, `save_product_image`, `delete_product_image`, `get_product_images`, `search_products`, `archive_product`, `unarchive_product` |
-| **Listings** | 15 | `create_draft_listing`, `list_draft_listings`, `get_draft_listing`, `update_draft_listing`, `approve_draft_listing`, `reject_draft_listing`, `revise_draft_listing`, `publish_listing`, `relist_product`, `cancel_listing`, `get_categories`, `get_shipping_options`, `get_shipping_types`, `get_tradera_item`, `get_attribute_definitions` |
+| **Listings** | 17 | `create_draft_listing`, `list_draft_listings`, `get_draft_listing`, `update_draft_listing`, `approve_draft_listing`, `reject_draft_listing`, `revise_draft_listing`, `publish_listing`, `relist_product`, `cancel_listing`, `end_tradera_listing`, `update_tradera_listing_price`, `get_categories`, `get_shipping_options`, `get_shipping_types`, `get_tradera_item`, `get_attribute_definitions` |
 | **Orders** | 8 | `check_new_orders`, `list_orders`, `get_order`, `create_sale_voucher`, `mark_order_shipped`, `create_shipping_label`, `list_orders_pending_feedback`, `leave_feedback` |
 | **Accounting** | 3 | `create_voucher`, `list_vouchers`, `export_vouchers` |
 | **Pricing** | 1 | `price_check` |
 | **Scout** | 6 | `create_saved_search`, `list_saved_searches`, `update_saved_search`, `delete_saved_search`, `run_saved_search`, `run_all_saved_searches` |
-| **Marketing** | 5 | `refresh_listing_stats`, `analyze_listing`, `get_performance_report`, `get_recommendations`, `listing_dashboard` |
+| **Marketing** | 8 | `refresh_listing_stats`, `analyze_listing`, `get_performance_report`, `get_recommendations`, `listing_dashboard`, `list_price_proposals`, `approve_price_proposal`, `reject_price_proposal` |
 | **Analytics** | 6 | `business_summary`, `profitability_report`, `inventory_report`, `period_comparison`, `sourcing_analysis`, `usage_report` |
 | **System** | 1 | `request_tools` |
 
@@ -105,6 +105,7 @@ All agent actions are logged to the `agent_actions` table for full audit trail.
 | Scout digest | Daily at 08:00 (configurable) | Runs all saved searches, sends digest of new finds |
 | Marketing refresh | Daily at 07:00 (configurable) | Refreshes listing stats, sends high-priority recommendations |
 | Listing dashboard | Daily at 07:00 (configurable) | Per-listing performance dashboard with views, watchers, bids, and trends |
+| Repricing check | Daily at 09:00 (configurable) | Generates price proposals from marketing recommendations, sends digest |
 | Weekly comparison | Sundays at 18:00 | Period comparison report (this week vs last) |
 
 Scheduled jobs require the bot to have received at least one `/start` command to register the owner chat ID for notifications.

--- a/src/storebot/bot/handlers.py
+++ b/src/storebot/bot/handlers.py
@@ -506,6 +506,39 @@ async def daily_listing_report_job(context: ContextTypes.DEFAULT_TYPE) -> None:
         await _alert_admin(context, "Fel i annonsrapport-jobbet. Kontrollera loggarna.")
 
 
+async def repricing_check_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    logger.info("Starting scheduled job: repricing_check", extra={"job_name": "repricing_check"})
+    agent: Agent = context.bot_data.get("agent")
+    if not agent or not agent.repricing:
+        return
+
+    try:
+        result = agent.repricing.generate_proposals()
+        proposals = result.get("proposals", [])
+        if not proposals:
+            return
+
+        chat_id = context.bot_data.get("owner_chat_id")
+        if not chat_id:
+            logger.warning("No owner_chat_id set — cannot send repricing proposals")
+            return
+
+        lines = [f"Prisförslag ({len(proposals)} st)\n"]
+        for p in proposals:
+            direction = "Sänk" if p["proposal_type"] == "reprice_lower" else "Höj"
+            lines.append(
+                f"{direction}: {p.get('listing_title', 'Annons #' + str(p['listing_id']))}"
+            )
+            lines.append(f"  {p['current_price']:.0f} kr \u2192 {p['suggested_price']:.0f} kr")
+            lines.append(f"  {p['reason']}\n")
+        lines.append("Godkänn eller avvisa med approve_price_proposal / reject_price_proposal.")
+        text = "\n".join(lines).strip()
+        await _send(context, chat_id, html_escape(text))
+    except Exception:
+        logger.exception("Error in repricing check job", extra={"job_name": "repricing_check"})
+        await _alert_admin(context, "Fel i prisförslags-jobbet. Kontrollera loggarna.")
+
+
 async def check_expired_listings_job(context: ContextTypes.DEFAULT_TYPE) -> None:
     logger.info(
         "Starting scheduled job: check_expired_listings",
@@ -657,6 +690,15 @@ def main() -> None:
         logger.info(
             "Listing dashboard report scheduled daily at %02d:00",
             settings.listing_report_hour,
+        )
+
+        app.job_queue.run_daily(
+            repricing_check_job,
+            time=dt_time(hour=settings.repricing_check_hour),
+        )
+        logger.info(
+            "Repricing check scheduled daily at %02d:00",
+            settings.repricing_check_hour,
         )
 
         app.job_queue.run_daily(

--- a/src/storebot/bot/handlers.py
+++ b/src/storebot/bot/handlers.py
@@ -513,7 +513,7 @@ async def repricing_check_job(context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     try:
-        result = agent.repricing.generate_proposals()
+        result = agent.repricing.generate_proposals(skip_refresh=True)
         proposals = result.get("proposals", [])
         if not proposals:
             return

--- a/src/storebot/config.py
+++ b/src/storebot/config.py
@@ -63,6 +63,7 @@ class Settings(BaseSettings):
     # Marketing
     marketing_refresh_hour: int = 7  # Hour (0-23) for daily stats refresh
     listing_report_hour: int = 7  # Hour (0-23) for daily listing dashboard report
+    repricing_check_hour: int = 9  # Hour (0-23) for daily repricing proposal check
 
     # Database
     database_path: str = "data/storebot.db"

--- a/src/storebot/db.py
+++ b/src/storebot/db.py
@@ -93,6 +93,7 @@ class PlatformListing(Base):
 
     product: Mapped["Product"] = relationship(back_populates="listings")
     snapshots: Mapped[list["ListingSnapshot"]] = relationship(back_populates="listing")
+    price_proposals: Mapped[list["PriceProposal"]] = relationship(back_populates="listing")
 
 
 class ListingSnapshot(Base):
@@ -239,6 +240,26 @@ class TraderaCategory(Base):
     depth: Mapped[int] = mapped_column(Integer, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     synced_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+
+class PriceProposal(Base):
+    __tablename__ = "price_proposals"
+    __table_args__ = (sa.Index("ix_price_proposals_listing_status", "listing_id", "status"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    listing_id: Mapped[int] = mapped_column(ForeignKey("platform_listings.id"), nullable=False)
+    proposal_type: Mapped[str] = mapped_column(String, nullable=False)
+    current_price: Mapped[float] = mapped_column(Float, nullable=False)
+    suggested_price: Mapped[float] = mapped_column(Float, nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(String, default="pending")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime)
+    executed_at: Mapped[datetime | None] = mapped_column(DateTime)
+    execution_error: Mapped[str | None] = mapped_column(Text)
+    details: Mapped[dict | None] = mapped_column(JSON)
+
+    listing: Mapped["PlatformListing"] = relationship(back_populates="price_proposals")
 
 
 class ApiUsage(Base):

--- a/src/storebot/tools/definitions.py
+++ b/src/storebot/tools/definitions.py
@@ -1119,14 +1119,14 @@ TOOLS = [
     # --- Repricing (marketing category) ---
     {
         "name": "list_price_proposals",
-        "description": "Lista prisförslag för annonser. Kan filtreras på status (pending, approved, rejected, executed, failed).",
+        "description": "Lista prisförslag för annonser. Kan filtreras på status (pending, rejected, executed, failed).",
         "category": "marketing",
         "input_schema": {
             "type": "object",
             "properties": {
                 "status": {
                     "type": "string",
-                    "description": "Filter on proposal status (pending, approved, rejected, executed, failed). Omit to show all.",
+                    "description": "Filter on proposal status (pending, rejected, executed, failed). Omit to show all.",
                 },
             },
             "additionalProperties": False,

--- a/src/storebot/tools/definitions.py
+++ b/src/storebot/tools/definitions.py
@@ -1116,6 +1116,89 @@ TOOLS = [
         "strict": True,
         "input_schema": _EMPTY_SCHEMA,
     },
+    # --- Repricing (marketing category) ---
+    {
+        "name": "list_price_proposals",
+        "description": "Lista prisförslag för annonser. Kan filtreras på status (pending, approved, rejected, executed, failed).",
+        "category": "marketing",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "description": "Filter on proposal status (pending, approved, rejected, executed, failed). Omit to show all.",
+                },
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "approve_price_proposal",
+        "description": "Godkänn ett prisförslag och genomför prisändringen på Tradera direkt.",
+        "category": "marketing",
+        "strict": True,
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "proposal_id": {
+                    "type": "integer",
+                    "description": "ID för prisförslaget att godkänna",
+                },
+            },
+            "required": ["proposal_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "reject_price_proposal",
+        "description": "Avvisa ett prisförslag med valfri motivering.",
+        "category": "marketing",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "proposal_id": {
+                    "type": "integer",
+                    "description": "ID för prisförslaget att avvisa",
+                },
+                "reason": {"type": "string", "description": "Anledning till avvisning (valfritt)"},
+            },
+            "required": ["proposal_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "end_tradera_listing",
+        "description": "Avsluta en aktiv annons på Tradera (EndItem SOAP) och uppdatera lokal status till cancelled.",
+        "category": "listing",
+        "strict": True,
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "listing_id": {"type": "integer", "description": "ID för annonsen att avsluta"},
+            },
+            "required": ["listing_id"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "update_tradera_listing_price",
+        "description": "Ändra pris på en aktiv Tradera-annons (SetPrices SOAP). Stöder startpris, köp-nu-pris och reservationspris.",
+        "category": "listing",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "listing_id": {"type": "integer", "description": "ID för annonsen"},
+                "start_price": {"type": "integer", "description": "Nytt startpris (auktioner)"},
+                "buy_it_now_price": {"type": "integer", "description": "Nytt köp-nu-pris"},
+                "reserve_price": {
+                    "type": "integer",
+                    "description": "Nytt reservationspris (auktioner)",
+                },
+            },
+            "required": ["listing_id"],
+            "additionalProperties": False,
+        },
+    },
     # --- Analytics ---
     {
         "name": "business_summary",

--- a/src/storebot/tools/definitions.py
+++ b/src/storebot/tools/definitions.py
@@ -1192,7 +1192,7 @@ TOOLS = [
                 "buy_it_now_price": {"type": "integer", "description": "Nytt köp-nu-pris"},
                 "reserve_price": {
                     "type": "integer",
-                    "description": "Nytt reservationspris (auktioner)",
+                    "description": "Nytt reservationspris (auktioner, skickas till Tradera men sparas ej lokalt)",
                 },
             },
             "required": ["listing_id"],

--- a/src/storebot/tools/dispatch.py
+++ b/src/storebot/tools/dispatch.py
@@ -85,6 +85,11 @@ DISPATCH: dict[str, tuple[str, str]] = {
     "get_performance_report": ("marketing", "get_performance_report"),
     "get_recommendations": ("marketing", "get_recommendations"),
     "listing_dashboard": ("marketing", "get_listing_dashboard"),
+    "list_price_proposals": ("repricing", "list_proposals"),
+    "approve_price_proposal": ("repricing", "approve_proposal"),
+    "reject_price_proposal": ("repricing", "reject_proposal"),
+    "end_tradera_listing": ("listing", "end_tradera_listing"),
+    "update_tradera_listing_price": ("listing", "update_live_listing_price"),
     "business_summary": ("analytics", "business_summary"),
     "profitability_report": ("analytics", "profitability_report"),
     "inventory_report": ("analytics", "inventory_report"),
@@ -100,6 +105,7 @@ DB_SERVICES: dict[str, str] = {
     "accounting": "AccountingService",
     "scout": "ScoutService",
     "marketing": "MarketingService",
+    "repricing": "RepricingService",
     "analytics": "AnalyticsService",
 }
 
@@ -118,6 +124,7 @@ def create_services(settings: Settings, engine: sa.Engine | None) -> dict[str, o
     from storebot.tools.order import OrderService
     from storebot.tools.postnord import Address, PostNordClient
     from storebot.tools.pricing import PricingService
+    from storebot.tools.repricing import RepricingService
     from storebot.tools.scout import ScoutService
     from storebot.tools.tradera import TraderaClient
 
@@ -150,6 +157,8 @@ def create_services(settings: Settings, engine: sa.Engine | None) -> dict[str, o
             sandbox=settings.postnord_sandbox,
         )
 
+    marketing = MarketingService(engine=engine, tradera=tradera) if engine else None
+
     return {
         "tradera": tradera,
         "blocket": blocket,
@@ -174,7 +183,12 @@ def create_services(settings: Settings, engine: sa.Engine | None) -> dict[str, o
         "scout": (
             ScoutService(engine=engine, tradera=tradera, blocket=blocket) if engine else None
         ),
-        "marketing": (MarketingService(engine=engine, tradera=tradera) if engine else None),
+        "marketing": marketing,
+        "repricing": (
+            RepricingService(engine=engine, marketing=marketing, tradera=tradera)
+            if engine
+            else None
+        ),
         "analytics": AnalyticsService(engine=engine) if engine else None,
         # Not in DISPATCH (PostNord is accessed via OrderService internally),
         # but exposed here so Agent.__init__'s setattr loop sets agent.postnord.

--- a/src/storebot/tools/listing.py
+++ b/src/storebot/tools/listing.py
@@ -1120,12 +1120,16 @@ class ListingService:
             )
             session.commit()
 
-            return {
+            result = {
                 "listing_id": listing_id,
                 "updated": True,
                 "start_price": listing.start_price,
                 "buy_it_now_price": listing.buy_it_now_price,
             }
+            # reserve_price has no local DB column but include if sent to Tradera
+            if reserve_price is not None:
+                result["reserve_price"] = reserve_price
+            return result
 
     def cancel_listing(self, listing_id: int) -> dict:
         """Cancel an active listing locally, attempting Tradera EndItem best-effort."""

--- a/src/storebot/tools/listing.py
+++ b/src/storebot/tools/listing.py
@@ -1184,7 +1184,7 @@ class ListingService:
             return result
 
 
-def _maybe_revert_product_status(session, listing) -> Product | None:
+def _maybe_revert_product_status(session: Session, listing: PlatformListing) -> Product | None:
     """Revert product to 'draft' if no other active listings remain.
 
     Returns the product if found, else None.

--- a/src/storebot/tools/listing.py
+++ b/src/storebot/tools/listing.py
@@ -993,21 +993,7 @@ class ListingService:
             expired_info = []
             for listing in expired:
                 listing.status = "ended"
-
-                other_active = (
-                    session.query(PlatformListing)
-                    .filter(
-                        PlatformListing.product_id == listing.product_id,
-                        PlatformListing.id != listing.id,
-                        PlatformListing.status == "active",
-                    )
-                    .count()
-                )
-
-                product = session.get(Product, listing.product_id)
-                if product and other_active == 0 and product.status == "listed":
-                    product.status = "draft"
-
+                _maybe_revert_product_status(session, listing)
                 expired_info.append(
                     (listing.id, listing.product_id, listing.listing_title, listing.ends_at)
                 )
@@ -1039,8 +1025,110 @@ class ListingService:
                 "expired_listings": result_listings,
             }
 
+    def end_tradera_listing(self, listing_id: int) -> dict:
+        """End a live listing on Tradera and update local status."""
+        if not self.tradera:
+            return {"error": "Tradera client not configured"}
+
+        with Session(self.engine) as session:
+            listing = session.get(PlatformListing, listing_id)
+            if listing is None:
+                return {"error": f"Listing {listing_id} not found"}
+
+            if listing.status != "active":
+                return {
+                    "error": f"Cannot end listing with status '{listing.status}', must be 'active'"
+                }
+
+            if not listing.external_id:
+                return {"error": f"Listing {listing_id} has no external_id (not published)"}
+
+            result = self.tradera.end_item(int(listing.external_id))
+            if "error" in result:
+                return result
+
+            listing.status = "cancelled"
+            product = _maybe_revert_product_status(session, listing)
+
+            log_action(
+                session,
+                "listing",
+                "end_tradera_listing",
+                {"listing_id": listing_id, "external_id": listing.external_id},
+                product_id=listing.product_id,
+            )
+            session.commit()
+
+            return {
+                "listing_id": listing_id,
+                "status": "cancelled",
+                "product_status": product.status if product else None,
+            }
+
+    def update_live_listing_price(
+        self,
+        listing_id: int,
+        start_price: int | None = None,
+        buy_it_now_price: int | None = None,
+        reserve_price: int | None = None,
+    ) -> dict:
+        """Change prices on a live Tradera listing and update local DB."""
+        if not self.tradera:
+            return {"error": "Tradera client not configured"}
+
+        with Session(self.engine) as session:
+            listing = session.get(PlatformListing, listing_id)
+            if listing is None:
+                return {"error": f"Listing {listing_id} not found"}
+
+            if listing.status != "active":
+                return {
+                    "error": f"Cannot update price on listing with status '{listing.status}', "
+                    "must be 'active'"
+                }
+
+            if not listing.external_id:
+                return {"error": f"Listing {listing_id} has no external_id (not published)"}
+
+            result = self.tradera.set_prices(
+                item_id=int(listing.external_id),
+                listing_type=listing.listing_type or "auction",
+                start_price=start_price,
+                buy_it_now_price=buy_it_now_price,
+                reserve_price=reserve_price,
+            )
+            if "error" in result:
+                return result
+
+            if start_price is not None:
+                listing.start_price = float(start_price)
+            if buy_it_now_price is not None:
+                listing.buy_it_now_price = float(buy_it_now_price)
+
+            log_action(
+                session,
+                "listing",
+                "update_live_listing_price",
+                {
+                    "listing_id": listing_id,
+                    "external_id": listing.external_id,
+                    "start_price": start_price,
+                    "buy_it_now_price": buy_it_now_price,
+                    "reserve_price": reserve_price,
+                },
+                product_id=listing.product_id,
+            )
+            session.commit()
+
+            return {
+                "listing_id": listing_id,
+                "updated": True,
+                "start_price": listing.start_price,
+                "buy_it_now_price": listing.buy_it_now_price,
+            }
+
     def cancel_listing(self, listing_id: int) -> dict:
-        """Cancel an active listing locally. Tradera has no cancel API."""
+        """Cancel an active listing locally, attempting Tradera EndItem best-effort."""
         with Session(self.engine) as session:
             listing = session.get(PlatformListing, listing_id)
             if listing is None:
@@ -1052,21 +1140,23 @@ class ListingService:
                     "must be 'active'"
                 }
 
+            # Best-effort Tradera cancellation
+            tradera_warning = None
+            if self.tradera and listing.external_id:
+                tradera_result = self.tradera.end_item(int(listing.external_id))
+                if "error" in tradera_result:
+                    tradera_warning = (
+                        f"Tradera EndItem misslyckades: {tradera_result['error']}. "
+                        "Annonsen kan fortfarande vara aktiv på Tradera."
+                    )
+                    logger.warning(
+                        "Best-effort EndItem failed for listing %d: %s",
+                        listing_id,
+                        tradera_result["error"],
+                    )
+
             listing.status = "cancelled"
-
-            other_active = (
-                session.query(PlatformListing)
-                .filter(
-                    PlatformListing.product_id == listing.product_id,
-                    PlatformListing.id != listing_id,
-                    PlatformListing.status == "active",
-                )
-                .count()
-            )
-
-            product = session.get(Product, listing.product_id)
-            if product and other_active == 0 and product.status == "listed":
-                product.status = "draft"
+            product = _maybe_revert_product_status(session, listing)
 
             log_action(
                 session,
@@ -1074,20 +1164,42 @@ class ListingService:
                 "cancel_listing",
                 {
                     "listing_id": listing_id,
-                    "note": "Local cancel only — Tradera listing may still be active on platform",
+                    "tradera_warning": tradera_warning,
                 },
                 product_id=listing.product_id,
             )
             session.commit()
 
-            return {
+            result = {
                 "listing_id": listing_id,
                 "status": "cancelled",
                 "product_status": product.status if product else None,
-                "warning": "Annulleringen gäller bara lokalt. "
-                "Tradera har inget API för att avbryta en pågående annons — "
-                "gör det manuellt på Tradera om det behövs.",
             }
+            if tradera_warning:
+                result["warning"] = tradera_warning
+            return result
+
+
+def _maybe_revert_product_status(session, listing) -> Product | None:
+    """Revert product to 'draft' if no other active listings remain.
+
+    Returns the product if found, else None.
+    """
+    if not listing.product_id:
+        return None
+    other_active = (
+        session.query(PlatformListing)
+        .filter(
+            PlatformListing.product_id == listing.product_id,
+            PlatformListing.id != listing.id,
+            PlatformListing.status == "active",
+        )
+        .count()
+    )
+    product = session.get(Product, listing.product_id)
+    if product and other_active == 0 and product.status == "listed":
+        product.status = "draft"
+    return product
 
 
 def _validate_draft(

--- a/src/storebot/tools/repricing.py
+++ b/src/storebot/tools/repricing.py
@@ -48,7 +48,7 @@ class RepricingService:
         recs_result = self.marketing.get_recommendations()
         recs = recs_result.get("recommendations", [])
 
-        reprice_recs = [r for r in recs if r["type"] in ("reprice_lower", "reprice_raise")]
+        reprice_recs = [r for r in recs if r["type"] in PROPOSAL_TYPES]
         if not reprice_recs:
             return {"new_proposals": 0, "proposals": []}
 
@@ -171,7 +171,7 @@ class RepricingService:
                         ),
                         "proposal_type": p.proposal_type,
                         "current_price": p.current_price,
-                        "suggested_price": p.suggested_price,
+                        "suggested_price": int(p.suggested_price),
                         "reason": p.reason,
                         "status": p.status,
                         "created_at": p.created_at.isoformat() if p.created_at else None,
@@ -198,9 +198,7 @@ class RepricingService:
                     "must be 'pending'"
                 }
 
-            proposal.status = "approved"
             proposal.decided_at = datetime.now(UTC)
-
             result = self._execute_proposal(proposal, session)
 
             log_action(
@@ -327,14 +325,14 @@ class RepricingService:
         """
         if proposal_type == "reprice_lower":
             raw = current_price * 0.85
-            suggested = int(math.ceil(raw / 10) * 10)
+            suggested = int(round(raw / 10) * 10)
             if product and product.acquisition_cost:
                 # acquisition_cost is the gross (VAT-inclusive) purchase price
-                floor = int(math.ceil(product.acquisition_cost * 1.1 / 10) * 10)
+                floor = int(math.ceil(round(product.acquisition_cost * 1.1, 2) / 10) * 10)
                 suggested = max(suggested, floor)
         else:
             # reprice_raise
             raw = current_price * 1.20
-            suggested = int(math.ceil(raw / 10) * 10)
+            suggested = int(round(raw / 10) * 10)
 
         return max(suggested, 10)  # minimum 10 kr

--- a/src/storebot/tools/repricing.py
+++ b/src/storebot/tools/repricing.py
@@ -1,0 +1,322 @@
+"""Proactive repricing service.
+
+Generates price proposals from marketing recommendations, stores them
+for human approval, and executes approved changes via Tradera SOAP.
+"""
+
+import logging
+import math
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session, selectinload
+
+from storebot.db import PlatformListing, PriceProposal, Product
+from storebot.tools.helpers import log_action
+
+logger = logging.getLogger(__name__)
+
+PROPOSAL_STATUSES = {"pending", "approved", "rejected", "executed", "failed"}
+PROPOSAL_TYPES = {"reprice_lower", "reprice_raise"}
+
+
+class RepricingService:
+    """Generates, stores, and executes price proposals for active listings."""
+
+    def __init__(self, engine, marketing=None, tradera=None):
+        self.engine = engine
+        self.marketing = marketing
+        self.tradera = tradera
+
+    def generate_proposals(self, skip_refresh: bool = False) -> dict:
+        """Generate price proposals from marketing recommendations.
+
+        Calls marketing.refresh_listing_stats() then marketing.get_recommendations(),
+        filters for reprice_lower/reprice_raise, deduplicates, and creates proposals.
+
+        Set *skip_refresh* to True when stats were already refreshed recently
+        (e.g. by the daily listing report job) to avoid burning Tradera API quota.
+        """
+        if not self.marketing:
+            return {"error": "MarketingService not available"}
+
+        if not skip_refresh:
+            self.marketing.refresh_listing_stats()
+        recs_result = self.marketing.get_recommendations()
+        recs = recs_result.get("recommendations", [])
+
+        reprice_recs = [r for r in recs if r["type"] in ("reprice_lower", "reprice_raise")]
+        if not reprice_recs:
+            return {"new_proposals": 0, "proposals": []}
+
+        with Session(self.engine) as session:
+            # Find listings with existing pending proposals for dedup
+            listing_ids = [r["listing_id"] for r in reprice_recs]
+            pending_listing_ids = {
+                row[0]
+                for row in session.query(PriceProposal.listing_id)
+                .filter(
+                    PriceProposal.listing_id.in_(listing_ids),
+                    PriceProposal.status == "pending",
+                )
+                .all()
+            }
+
+            # Bulk-load all candidate listings in one query (avoids N+1)
+            candidate_ids = [
+                r["listing_id"] for r in reprice_recs if r["listing_id"] not in pending_listing_ids
+            ]
+            listings_by_id = (
+                {
+                    lst.id: lst
+                    for lst in session.query(PlatformListing)
+                    .options(selectinload(PlatformListing.product))
+                    .filter(
+                        PlatformListing.id.in_(candidate_ids),
+                        PlatformListing.status == "active",
+                    )
+                    .all()
+                }
+                if candidate_ids
+                else {}
+            )
+
+            new_proposals = []
+            for rec in reprice_recs:
+                lid = rec["listing_id"]
+                listing = listings_by_id.get(lid)
+                if not listing:
+                    continue
+
+                current_price = listing.buy_it_now_price or listing.start_price or 0
+                if current_price <= 0:
+                    continue
+
+                product = listing.product
+                suggested = self._compute_suggested_price(current_price, rec["type"], product)
+                if suggested == int(current_price):
+                    continue
+
+                proposal = PriceProposal(
+                    listing_id=lid,
+                    proposal_type=rec["type"],
+                    current_price=current_price,
+                    suggested_price=float(suggested),
+                    reason=rec.get("suggestion", ""),
+                    status="pending",
+                    details={
+                        "recommendation": rec,
+                        "listing_type": listing.listing_type,
+                        "product_title": product.title if product else None,
+                    },
+                )
+                session.add(proposal)
+                new_proposals.append((proposal, listing, rec))
+
+            # Single flush assigns IDs to all new proposals
+            session.flush()
+            proposals = [
+                {
+                    "proposal_id": p.id,
+                    "listing_id": p.listing_id,
+                    "listing_title": lst.listing_title,
+                    "proposal_type": rec["type"],
+                    "current_price": p.current_price,
+                    "suggested_price": int(p.suggested_price),
+                    "reason": p.reason,
+                }
+                for p, lst, rec in new_proposals
+            ]
+
+            log_action(
+                session,
+                "repricing",
+                "generate_proposals",
+                {"new_proposals": len(proposals)},
+            )
+            session.commit()
+
+            return {"new_proposals": len(proposals), "proposals": proposals}
+
+    def list_proposals(self, status: str | None = None) -> dict:
+        """List price proposals, optionally filtered by status."""
+        with Session(self.engine) as session:
+            q = session.query(PriceProposal).options(
+                selectinload(PriceProposal.listing).selectinload(PlatformListing.product)
+            )
+            if status:
+                q = q.filter(PriceProposal.status == status)
+
+            proposals = q.order_by(PriceProposal.created_at.desc()).all()
+
+            return {
+                "count": len(proposals),
+                "proposals": [
+                    {
+                        "proposal_id": p.id,
+                        "listing_id": p.listing_id,
+                        "listing_title": p.listing.listing_title if p.listing else None,
+                        "product_title": (
+                            p.listing.product.title if p.listing and p.listing.product else None
+                        ),
+                        "proposal_type": p.proposal_type,
+                        "current_price": p.current_price,
+                        "suggested_price": p.suggested_price,
+                        "reason": p.reason,
+                        "status": p.status,
+                        "created_at": p.created_at.isoformat() if p.created_at else None,
+                        "decided_at": p.decided_at.isoformat() if p.decided_at else None,
+                        "executed_at": p.executed_at.isoformat() if p.executed_at else None,
+                        "execution_error": p.execution_error,
+                    }
+                    for p in proposals
+                ],
+            }
+
+    def approve_proposal(self, proposal_id: int) -> dict:
+        """Approve a pending proposal and immediately execute the price change."""
+        with Session(self.engine) as session:
+            proposal = session.get(PriceProposal, proposal_id)
+            if proposal is None:
+                return {"error": f"Proposal {proposal_id} not found"}
+
+            if proposal.status != "pending":
+                return {
+                    "error": f"Cannot approve proposal with status '{proposal.status}', "
+                    "must be 'pending'"
+                }
+
+            proposal.status = "approved"
+            proposal.decided_at = datetime.now(UTC)
+
+            result = self._execute_proposal(proposal, session)
+
+            log_action(
+                session,
+                "repricing",
+                "approve_proposal",
+                {
+                    "proposal_id": proposal_id,
+                    "listing_id": proposal.listing_id,
+                    "result": result,
+                },
+            )
+            session.commit()
+
+            return result
+
+    def reject_proposal(self, proposal_id: int, reason: str | None = None) -> dict:
+        """Reject a pending proposal."""
+        with Session(self.engine) as session:
+            proposal = session.get(PriceProposal, proposal_id)
+            if proposal is None:
+                return {"error": f"Proposal {proposal_id} not found"}
+
+            if proposal.status != "pending":
+                return {
+                    "error": f"Cannot reject proposal with status '{proposal.status}', "
+                    "must be 'pending'"
+                }
+
+            proposal.status = "rejected"
+            proposal.decided_at = datetime.now(UTC)
+            if reason:
+                proposal.details = {**(proposal.details or {}), "rejection_reason": reason}
+
+            log_action(
+                session,
+                "repricing",
+                "reject_proposal",
+                {"proposal_id": proposal_id, "reason": reason},
+            )
+            session.commit()
+
+            return {
+                "proposal_id": proposal_id,
+                "status": "rejected",
+                "reason": reason,
+            }
+
+    def _execute_proposal(self, proposal: PriceProposal, session: Session) -> dict:
+        """Execute an approved price change via Tradera."""
+        if not self.tradera:
+            proposal.status = "failed"
+            proposal.execution_error = "Tradera client not configured"
+            return {"error": proposal.execution_error}
+
+        listing = proposal.listing
+        if not listing or listing.status != "active":
+            proposal.status = "failed"
+            proposal.execution_error = "Listing is no longer active"
+            return {"error": proposal.execution_error}
+
+        if not listing.external_id:
+            proposal.status = "failed"
+            proposal.execution_error = "Listing has no external_id"
+            return {"error": proposal.execution_error}
+
+        listing_type = listing.listing_type or "auction"
+        suggested = int(proposal.suggested_price)
+
+        if listing_type == "buy_it_now":
+            tradera_result = self.tradera.set_prices(
+                item_id=int(listing.external_id),
+                listing_type="buy_it_now",
+                buy_it_now_price=suggested,
+            )
+        else:
+            tradera_result = self.tradera.set_prices(
+                item_id=int(listing.external_id),
+                listing_type="auction",
+                start_price=suggested,
+            )
+
+        if "error" in tradera_result:
+            proposal.status = "failed"
+            proposal.execution_error = tradera_result["error"]
+            proposal.executed_at = datetime.now(UTC)
+            return {
+                "proposal_id": proposal.id,
+                "status": "failed",
+                "error": tradera_result["error"],
+            }
+
+        # Success: update local listing prices
+        proposal.status = "executed"
+        proposal.executed_at = datetime.now(UTC)
+
+        if listing_type == "buy_it_now":
+            listing.buy_it_now_price = float(suggested)
+        else:
+            listing.start_price = float(suggested)
+
+        return {
+            "proposal_id": proposal.id,
+            "listing_id": proposal.listing_id,
+            "status": "executed",
+            "old_price": proposal.current_price,
+            "new_price": float(suggested),
+        }
+
+    @staticmethod
+    def _compute_suggested_price(
+        current_price: float,
+        proposal_type: str,
+        product: Product | None,
+    ) -> int:
+        """Compute a suggested price based on the proposal type.
+
+        Lower: reduce 15%, round to nearest 10 kr, floor at acquisition_cost × 1.1.
+        Raise: increase 20%, round to nearest 10 kr.
+        """
+        if proposal_type == "reprice_lower":
+            raw = current_price * 0.85
+            suggested = int(math.ceil(raw / 10) * 10)
+            if product and product.acquisition_cost:
+                floor = int(math.ceil(product.acquisition_cost * 1.1 / 10) * 10)
+                suggested = max(suggested, floor)
+        else:
+            # reprice_raise
+            raw = current_price * 1.20
+            suggested = int(math.ceil(raw / 10) * 10)
+
+        return max(suggested, 10)  # minimum 10 kr

--- a/src/storebot/tools/repricing.py
+++ b/src/storebot/tools/repricing.py
@@ -15,7 +15,7 @@ from storebot.tools.helpers import log_action
 
 logger = logging.getLogger(__name__)
 
-PROPOSAL_STATUSES = {"pending", "approved", "rejected", "executed", "failed"}
+PROPOSAL_STATUSES = {"pending", "rejected", "executed", "failed"}
 PROPOSAL_TYPES = {"reprice_lower", "reprice_raise"}
 
 
@@ -91,7 +91,11 @@ class RepricingService:
                 if not listing:
                     continue
 
-                current_price = listing.buy_it_now_price or listing.start_price or 0
+                # Use the price field that _execute_proposal will actually change
+                if listing.listing_type == "buy_it_now":
+                    current_price = listing.buy_it_now_price or 0
+                else:
+                    current_price = listing.start_price or 0
                 if current_price <= 0:
                     continue
 

--- a/src/storebot/tools/repricing.py
+++ b/src/storebot/tools/repricing.py
@@ -40,7 +40,11 @@ class RepricingService:
             return {"error": "MarketingService not available"}
 
         if not skip_refresh:
-            self.marketing.refresh_listing_stats()
+            try:
+                self.marketing.refresh_listing_stats()
+            except Exception:
+                logger.exception("refresh_listing_stats failed during proposal generation")
+                return {"error": "Failed to refresh listing stats"}
         recs_result = self.marketing.get_recommendations()
         recs = recs_result.get("recommendations", [])
 
@@ -139,6 +143,9 @@ class RepricingService:
 
     def list_proposals(self, status: str | None = None) -> dict:
         """List price proposals, optionally filtered by status."""
+        if status and status not in PROPOSAL_STATUSES:
+            return {"error": f"Invalid status '{status}'. Valid: {sorted(PROPOSAL_STATUSES)}"}
+
         with Session(self.engine) as session:
             q = session.query(PriceProposal).options(
                 selectinload(PriceProposal.listing).selectinload(PlatformListing.product)
@@ -175,7 +182,9 @@ class RepricingService:
     def approve_proposal(self, proposal_id: int) -> dict:
         """Approve a pending proposal and immediately execute the price change."""
         with Session(self.engine) as session:
-            proposal = session.get(PriceProposal, proposal_id)
+            proposal = session.get(
+                PriceProposal, proposal_id, options=[selectinload(PriceProposal.listing)]
+            )
             if proposal is None:
                 return {"error": f"Proposal {proposal_id} not found"}
 
@@ -240,20 +249,24 @@ class RepricingService:
         """Execute an approved price change via Tradera."""
         if not self.tradera:
             proposal.status = "failed"
+            proposal.executed_at = datetime.now(UTC)
             proposal.execution_error = "Tradera client not configured"
             return {"error": proposal.execution_error}
 
         listing = proposal.listing
         if not listing or listing.status != "active":
             proposal.status = "failed"
+            proposal.executed_at = datetime.now(UTC)
             proposal.execution_error = "Listing is no longer active"
             return {"error": proposal.execution_error}
 
         if not listing.external_id:
             proposal.status = "failed"
+            proposal.executed_at = datetime.now(UTC)
             proposal.execution_error = "Listing has no external_id"
             return {"error": proposal.execution_error}
 
+        # listing_type defaults to "auction" for older records without explicit type
         listing_type = listing.listing_type or "auction"
         suggested = int(proposal.suggested_price)
 
@@ -312,6 +325,7 @@ class RepricingService:
             raw = current_price * 0.85
             suggested = int(math.ceil(raw / 10) * 10)
             if product and product.acquisition_cost:
+                # acquisition_cost is the gross (VAT-inclusive) purchase price
                 floor = int(math.ceil(product.acquisition_cost * 1.1 / 10) * 10)
                 suggested = max(suggested, floor)
         else:

--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -830,6 +830,9 @@ class TraderaClient:
         SetPriceOnShopItems for buy-it-now listings.
         All prices are integers (SEK).
         """
+        if start_price is None and buy_it_now_price is None and reserve_price is None:
+            return {"error": "At least one price field must be provided"}
+
         try:
             headers = self._auth_headers(self.restricted_client, include_authorization=True)
 

--- a/src/storebot/tools/tradera.py
+++ b/src/storebot/tools/tradera.py
@@ -790,6 +790,84 @@ class TraderaClient:
             request={"OrderId": int(order_id)}, **headers
         )
 
+    @retry_on_transient()
+    def _end_item_api_call(self, item_id, headers):
+        return self.restricted_client.service.EndItem(itemId=int(item_id), **headers)
+
+    def end_item(self, item_id: int) -> dict:
+        """End a live listing on Tradera."""
+        try:
+            self._end_item_api_call(
+                item_id,
+                self._auth_headers(self.restricted_client, include_authorization=True),
+            )
+            return {"item_id": item_id, "ended": True}
+        except Exception as e:
+            logger.exception("Tradera end_item failed")
+            return {"error": str(e)}
+
+    @retry_on_transient()
+    def _set_prices_non_shop_api_call(self, params, headers):
+        return self.restricted_client.service.SetPricesOnNonShopItems(
+            nonShopItem=params, **headers
+        )
+
+    @retry_on_transient()
+    def _set_prices_shop_api_call(self, params, headers):
+        return self.restricted_client.service.SetPriceOnShopItems(shopItems=params, **headers)
+
+    def set_prices(
+        self,
+        item_id: int,
+        listing_type: str,
+        start_price: int | None = None,
+        buy_it_now_price: int | None = None,
+        reserve_price: int | None = None,
+    ) -> dict:
+        """Change prices on a live Tradera listing.
+
+        Routes to SetPricesOnNonShopItems for auctions,
+        SetPriceOnShopItems for buy-it-now listings.
+        All prices are integers (SEK).
+        """
+        try:
+            headers = self._auth_headers(self.restricted_client, include_authorization=True)
+
+            if listing_type == "buy_it_now":
+                if buy_it_now_price is None:
+                    return {"error": "buy_it_now_price is required for buy-it-now listings"}
+                params = {
+                    "SetPriceShopItem": [{"Id": int(item_id), "Price": int(buy_it_now_price)}]
+                }
+                self._set_prices_shop_api_call(params, headers)
+                return {
+                    "item_id": item_id,
+                    "updated": True,
+                    "buy_it_now_price": buy_it_now_price,
+                }
+            else:
+                # Auction: SetPricesOnNonShopItems
+                params = {"Id": int(item_id)}
+                if start_price is not None:
+                    params["OpeningPrice"] = int(start_price)
+                if reserve_price is not None:
+                    params["ReservedPrice"] = int(reserve_price)
+                if buy_it_now_price is not None:
+                    params["BinPrice"] = int(buy_it_now_price)
+                self._set_prices_non_shop_api_call(params, headers)
+                result = {"item_id": item_id, "updated": True}
+                if start_price is not None:
+                    result["start_price"] = start_price
+                if reserve_price is not None:
+                    result["reserve_price"] = reserve_price
+                if buy_it_now_price is not None:
+                    result["buy_it_now_price"] = buy_it_now_price
+                return result
+
+        except Exception as e:
+            logger.exception("Tradera set_prices failed")
+            return {"error": str(e)}
+
     def mark_order_shipped(self, order_id: int) -> dict:
         try:
             self._mark_order_shipped_api_call(

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -83,6 +83,18 @@ class TestDispatchMapping:
         assert "get_categories" in DISPATCH
         assert DISPATCH["get_categories"] == ("tradera", "get_categories")
 
+    def test_repricing_tools_in_dispatch(self):
+        assert "list_price_proposals" in DISPATCH
+        assert DISPATCH["list_price_proposals"] == ("repricing", "list_proposals")
+        assert "approve_price_proposal" in DISPATCH
+        assert "reject_price_proposal" in DISPATCH
+
+    def test_tradera_write_tools_in_dispatch(self):
+        assert "end_tradera_listing" in DISPATCH
+        assert DISPATCH["end_tradera_listing"] == ("listing", "end_tradera_listing")
+        assert "update_tradera_listing_price" in DISPATCH
+        assert DISPATCH["update_tradera_listing_price"] == ("listing", "update_live_listing_price")
+
 
 class TestCreateServices:
     def test_creates_all_services_with_engine(self, engine):
@@ -96,6 +108,7 @@ class TestCreateServices:
         assert "accounting" in services
         assert "scout" in services
         assert "marketing" in services
+        assert "repricing" in services
         assert "analytics" in services
 
     def test_db_services_none_without_engine(self):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1573,6 +1573,7 @@ class TestRepricingCheckJob:
         context.bot_data = {"agent": agent, "owner_chat_id": 12345}
         context.bot.send_message = AsyncMock()
         await repricing_check_job(context)
+        repricing.generate_proposals.assert_called_once_with(skip_refresh=True)
         context.bot.send_message.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1606,6 +1606,30 @@ class TestRepricingCheckJob:
         context.bot.send_message.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_missing_owner_chat_id(self):
+        repricing = MagicMock()
+        repricing.generate_proposals.return_value = {
+            "new_proposals": 1,
+            "proposals": [
+                {
+                    "proposal_type": "reprice_lower",
+                    "listing_id": 1,
+                    "listing_title": "Test",
+                    "current_price": 500,
+                    "suggested_price": 430,
+                    "reason": "test",
+                },
+            ],
+        }
+        agent = MagicMock()
+        agent.repricing = repricing
+        context = MagicMock()
+        context.bot_data = {"agent": agent}
+        context.bot.send_message = AsyncMock()
+        await repricing_check_job(context)
+        context.bot.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_error_alerts_admin(self):
         repricing = MagicMock()
         repricing.generate_proposals.side_effect = RuntimeError("fail")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -32,6 +32,7 @@ from storebot.bot.handlers import (
     check_expired_listings_job,
     poll_orders_job,
     rapport_command,
+    repricing_check_job,
     scout_command,
     scout_digest_job,
     start,
@@ -1422,6 +1423,7 @@ class TestMain:
         mock_settings.scout_digest_hour = 7
         mock_settings.marketing_refresh_hour = 8
         mock_settings.listing_report_hour = 7
+        mock_settings.repricing_check_hour = 9
         mock_settings.expired_listings_check_interval_minutes = 60
 
         mock_app = MagicMock()
@@ -1453,6 +1455,7 @@ class TestMain:
                 scout_digest_job,
                 marketing_refresh_job,
                 daily_listing_report_job,
+                repricing_check_job,
                 weekly_comparison_job,
             }
 
@@ -1474,6 +1477,7 @@ class TestMain:
         mock_settings.scout_digest_hour = 7
         mock_settings.marketing_refresh_hour = 8
         mock_settings.listing_report_hour = 7
+        mock_settings.repricing_check_hour = 9
         mock_settings.expired_listings_check_interval_minutes = 60
 
         mock_app = MagicMock()
@@ -1539,3 +1543,77 @@ class TestAccessDeniedPaths:
         update, ctx = _denied_update_context()
         await handler(update, ctx)
         assert "nekad" in update.message.reply_text.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Repricing check job
+# ---------------------------------------------------------------------------
+
+
+class TestRepricingCheckJob:
+    @pytest.mark.asyncio
+    async def test_sends_proposals(self):
+        repricing = MagicMock()
+        repricing.generate_proposals.return_value = {
+            "new_proposals": 1,
+            "proposals": [
+                {
+                    "listing_id": 1,
+                    "listing_title": "Antik vas",
+                    "proposal_type": "reprice_lower",
+                    "current_price": 500.0,
+                    "suggested_price": 430.0,
+                    "reason": "Sänk priset.",
+                },
+            ],
+        }
+        agent = MagicMock()
+        agent.repricing = repricing
+        context = MagicMock()
+        context.bot_data = {"agent": agent, "owner_chat_id": 12345}
+        context.bot.send_message = AsyncMock()
+        await repricing_check_job(context)
+        context.bot.send_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_proposals_skips(self):
+        repricing = MagicMock()
+        repricing.generate_proposals.return_value = {"new_proposals": 0, "proposals": []}
+        agent = MagicMock()
+        agent.repricing = repricing
+        context = MagicMock()
+        context.bot_data = {"agent": agent, "owner_chat_id": 12345}
+        context.bot.send_message = AsyncMock()
+        await repricing_check_job(context)
+        context.bot.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_agent_returns(self):
+        context = MagicMock()
+        context.bot_data = {}
+        context.bot.send_message = AsyncMock()
+        await repricing_check_job(context)
+        context.bot.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_repricing_service(self):
+        agent = MagicMock()
+        agent.repricing = None
+        context = MagicMock()
+        context.bot_data = {"agent": agent}
+        context.bot.send_message = AsyncMock()
+        await repricing_check_job(context)
+        context.bot.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_error_alerts_admin(self):
+        repricing = MagicMock()
+        repricing.generate_proposals.side_effect = RuntimeError("fail")
+        agent = MagicMock()
+        agent.repricing = repricing
+        context = MagicMock()
+        context.bot_data = {"agent": agent, "owner_chat_id": 12345}
+        context.bot.send_message = AsyncMock()
+        await repricing_check_job(context)
+        # Should have sent alert
+        context.bot.send_message.assert_awaited()

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -2702,6 +2702,72 @@ class TestUpdateLiveListingPrice:
         result = svc.update_live_listing_price(lid, start_price=200)
         assert "error" in result
 
+    def test_reserve_price_in_result(self, engine):
+        tradera = MagicMock()
+        tradera.set_prices.return_value = {
+            "item_id": 999,
+            "updated": True,
+            "start_price": 200,
+            "reserve_price": 400,
+        }
+        svc = ListingService(engine=engine, tradera=tradera)
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Test",
+                start_price=300.0,
+                external_id="999",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.update_live_listing_price(lid, start_price=200, reserve_price=400)
+
+        assert "error" not in result
+        assert result["reserve_price"] == 400
+        tradera.set_prices.assert_called_once_with(
+            item_id=999,
+            listing_type="auction",
+            start_price=200,
+            buy_it_now_price=None,
+            reserve_price=400,
+        )
+
+    def test_no_reserve_price_omitted_from_result(self, engine):
+        tradera = MagicMock()
+        tradera.set_prices.return_value = {"item_id": 999, "updated": True, "start_price": 200}
+        svc = ListingService(engine=engine, tradera=tradera)
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Test",
+                start_price=300.0,
+                external_id="999",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.update_live_listing_price(lid, start_price=200)
+
+        assert "error" not in result
+        assert "reserve_price" not in result
+
     def test_no_tradera_client(self, engine):
         svc = ListingService(engine=engine, tradera=None)
         result = svc.update_live_listing_price(1, start_price=200)

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -1930,7 +1930,6 @@ class TestCancelListing:
         assert "error" not in result
         assert result["status"] == "cancelled"
         assert result["product_status"] == "draft"
-        assert "warning" in result
 
         with Session(engine) as session:
             listing = session.get(PlatformListing, draft["listing_id"])
@@ -2062,7 +2061,7 @@ class TestCancelListing:
             action = session.query(AgentAction).filter_by(action_type="cancel_listing").one()
             assert action.agent_name == "listing"
             assert action.product_id == product
-            assert "Local cancel only" in action.details["note"]
+            assert "listing_id" in action.details
 
 
 class TestCheckExpiredListings:
@@ -2486,3 +2485,282 @@ class TestFormatDraftPreviewEdgeCases:
         result = _format_draft_preview(listing, None)
         assert "Leveransvillkor" in result
         assert "Köparen betalar frakt" in result
+
+
+class TestEndTraderaListing:
+    def test_ends_active_listing(self, engine):
+        tradera = MagicMock()
+        tradera.end_item.return_value = {"item_id": 999, "ended": True}
+        svc = ListingService(engine=engine, tradera=tradera)
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Test listing",
+                external_id="999",
+            )
+            session.add(listing)
+            session.commit()
+            lid, pid = listing.id, p.id
+
+        result = svc.end_tradera_listing(lid)
+
+        assert "error" not in result
+        assert result["status"] == "cancelled"
+        tradera.end_item.assert_called_once_with(999)
+
+        with Session(engine) as session:
+            listing = session.get(PlatformListing, lid)
+            assert listing.status == "cancelled"
+            product = session.get(Product, pid)
+            assert product.status == "draft"
+
+    def test_not_active(self, engine):
+        svc = ListingService(engine=engine, tradera=MagicMock())
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="draft")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="draft",
+                listing_type="auction",
+                listing_title="Test",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.end_tradera_listing(lid)
+        assert "error" in result
+
+    def test_no_external_id(self, engine):
+        svc = ListingService(engine=engine, tradera=MagicMock())
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Test",
+                external_id=None,
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.end_tradera_listing(lid)
+        assert "error" in result
+
+    def test_tradera_error(self, engine):
+        tradera = MagicMock()
+        tradera.end_item.return_value = {"error": "SOAP fault"}
+        svc = ListingService(engine=engine, tradera=tradera)
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Test",
+                external_id="999",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.end_tradera_listing(lid)
+        assert "error" in result
+
+    def test_no_tradera_client(self, engine):
+        svc = ListingService(engine=engine, tradera=None)
+        result = svc.end_tradera_listing(1)
+        assert "error" in result
+
+
+class TestUpdateLiveListingPrice:
+    def test_updates_auction_price(self, engine):
+        tradera = MagicMock()
+        tradera.set_prices.return_value = {"item_id": 999, "updated": True, "start_price": 200}
+        svc = ListingService(engine=engine, tradera=tradera)
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Test",
+                start_price=300.0,
+                external_id="999",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.update_live_listing_price(lid, start_price=200)
+
+        assert "error" not in result
+        assert result["updated"] is True
+        tradera.set_prices.assert_called_once()
+
+        with Session(engine) as session:
+            listing = session.get(PlatformListing, lid)
+            assert listing.start_price == 200.0
+
+    def test_updates_buy_it_now_price(self, engine):
+        tradera = MagicMock()
+        tradera.set_prices.return_value = {"item_id": 999, "updated": True}
+        svc = ListingService(engine=engine, tradera=tradera)
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="buy_it_now",
+                listing_title="Test",
+                buy_it_now_price=800.0,
+                external_id="999",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.update_live_listing_price(lid, buy_it_now_price=700)
+
+        assert "error" not in result
+        with Session(engine) as session:
+            listing = session.get(PlatformListing, lid)
+            assert listing.buy_it_now_price == 700.0
+
+    def test_not_active(self, engine):
+        svc = ListingService(engine=engine, tradera=MagicMock())
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="draft")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="draft",
+                listing_type="auction",
+                listing_title="Test",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.update_live_listing_price(lid, start_price=200)
+        assert "error" in result
+
+    def test_tradera_error(self, engine):
+        tradera = MagicMock()
+        tradera.set_prices.return_value = {"error": "Cannot change price with bids"}
+        svc = ListingService(engine=engine, tradera=tradera)
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Test",
+                start_price=300.0,
+                external_id="999",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.update_live_listing_price(lid, start_price=200)
+        assert "error" in result
+
+    def test_no_tradera_client(self, engine):
+        svc = ListingService(engine=engine, tradera=None)
+        result = svc.update_live_listing_price(1, start_price=200)
+        assert "error" in result
+
+
+class TestCancelListingWithTradera:
+    def test_best_effort_end_item_success(self, engine):
+        tradera = MagicMock()
+        tradera.end_item.return_value = {"item_id": 999, "ended": True}
+        svc = ListingService(engine=engine, tradera=tradera)
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Test",
+                external_id="999",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.cancel_listing(lid)
+
+        assert "error" not in result
+        assert result["status"] == "cancelled"
+        assert "warning" not in result
+        tradera.end_item.assert_called_once_with(999)
+
+    def test_best_effort_end_item_failure_still_cancels(self, engine):
+        tradera = MagicMock()
+        tradera.end_item.return_value = {"error": "SOAP error"}
+        svc = ListingService(engine=engine, tradera=tradera)
+
+        with Session(engine) as session:
+            p = Product(title="Test", status="listed")
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Test",
+                external_id="999",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        result = svc.cancel_listing(lid)
+
+        assert "error" not in result
+        assert result["status"] == "cancelled"
+        assert "warning" in result
+        assert "SOAP error" in result["warning"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -26,6 +26,11 @@ class TestBuildTools:
         assert "search_tradera" in names
         assert "create_draft_listing" in names
         assert "business_summary" in names
+        assert "list_price_proposals" in names
+        assert "approve_price_proposal" in names
+        assert "reject_price_proposal" in names
+        assert "end_tradera_listing" in names
+        assert "update_tradera_listing_price" in names
 
     def test_tool_has_description(self):
         tools = _build_tools()

--- a/tests/test_repricing.py
+++ b/tests/test_repricing.py
@@ -1,0 +1,383 @@
+"""Tests for RepricingService."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from storebot.db import PlatformListing, PriceProposal, Product
+from storebot.tools.repricing import RepricingService
+
+
+@pytest.fixture
+def product(engine):
+    with Session(engine) as session:
+        p = Product(
+            title="Antik vas",
+            status="listed",
+            acquisition_cost=100.0,
+        )
+        session.add(p)
+        session.commit()
+        return p.id
+
+
+@pytest.fixture
+def active_listing(engine, product):
+    with Session(engine) as session:
+        listing = PlatformListing(
+            product_id=product,
+            platform="tradera",
+            status="active",
+            listing_type="auction",
+            listing_title="Antik vas 1920-tal",
+            start_price=500.0,
+            external_id="12345",
+        )
+        session.add(listing)
+        session.commit()
+        return listing.id
+
+
+@pytest.fixture
+def bin_listing(engine, product):
+    with Session(engine) as session:
+        listing = PlatformListing(
+            product_id=product,
+            platform="tradera",
+            status="active",
+            listing_type="buy_it_now",
+            listing_title="Antik vas köp nu",
+            buy_it_now_price=800.0,
+            external_id="67890",
+        )
+        session.add(listing)
+        session.commit()
+        return listing.id
+
+
+@pytest.fixture
+def marketing():
+    m = MagicMock()
+    m.refresh_listing_stats.return_value = {"refreshed": 0}
+    return m
+
+
+@pytest.fixture
+def tradera():
+    t = MagicMock()
+    t.set_prices.return_value = {"item_id": 12345, "updated": True}
+    return t
+
+
+@pytest.fixture
+def service(engine, marketing, tradera):
+    return RepricingService(engine=engine, marketing=marketing, tradera=tradera)
+
+
+class TestGenerateProposals:
+    def test_creates_proposals_from_recommendations(self, service, marketing, active_listing):
+        marketing.get_recommendations.return_value = {
+            "recommendations": [
+                {
+                    "listing_id": active_listing,
+                    "type": "reprice_lower",
+                    "priority": "medium",
+                    "suggestion": "Sänk priset — många visningar men inga bud.",
+                    "reason": "20 visningar, 0 bud.",
+                },
+            ],
+        }
+
+        result = service.generate_proposals()
+
+        assert "error" not in result
+        assert result["new_proposals"] == 1
+        assert len(result["proposals"]) == 1
+        assert result["proposals"][0]["proposal_type"] == "reprice_lower"
+        assert result["proposals"][0]["suggested_price"] < 500
+
+    def test_skips_non_reprice_recommendations(self, service, marketing, active_listing):
+        marketing.get_recommendations.return_value = {
+            "recommendations": [
+                {
+                    "listing_id": active_listing,
+                    "type": "relist",
+                    "priority": "high",
+                    "suggestion": "Lägg upp igen.",
+                },
+            ],
+        }
+
+        result = service.generate_proposals()
+        assert result["new_proposals"] == 0
+
+    def test_dedup_skips_existing_pending(self, service, marketing, engine, active_listing):
+        # Create an existing pending proposal
+        with Session(engine) as session:
+            session.add(
+                PriceProposal(
+                    listing_id=active_listing,
+                    proposal_type="reprice_lower",
+                    current_price=500.0,
+                    suggested_price=430.0,
+                    reason="existing",
+                    status="pending",
+                )
+            )
+            session.commit()
+
+        marketing.get_recommendations.return_value = {
+            "recommendations": [
+                {
+                    "listing_id": active_listing,
+                    "type": "reprice_lower",
+                    "priority": "medium",
+                    "suggestion": "Sänk priset.",
+                },
+            ],
+        }
+
+        result = service.generate_proposals()
+        assert result["new_proposals"] == 0
+
+    def test_no_marketing_returns_error(self, engine, tradera):
+        service = RepricingService(engine=engine, marketing=None, tradera=tradera)
+        result = service.generate_proposals()
+        assert "error" in result
+
+    def test_empty_recommendations(self, service, marketing):
+        marketing.get_recommendations.return_value = {"recommendations": []}
+        result = service.generate_proposals()
+        assert result["new_proposals"] == 0
+
+
+class TestListProposals:
+    def test_lists_all_proposals(self, service, engine, active_listing):
+        with Session(engine) as session:
+            session.add(
+                PriceProposal(
+                    listing_id=active_listing,
+                    proposal_type="reprice_lower",
+                    current_price=500.0,
+                    suggested_price=430.0,
+                    reason="test",
+                    status="pending",
+                )
+            )
+            session.commit()
+
+        result = service.list_proposals()
+        assert result["count"] == 1
+        assert result["proposals"][0]["status"] == "pending"
+
+    def test_filters_by_status(self, service, engine, active_listing):
+        with Session(engine) as session:
+            session.add(
+                PriceProposal(
+                    listing_id=active_listing,
+                    proposal_type="reprice_lower",
+                    current_price=500.0,
+                    suggested_price=430.0,
+                    reason="test",
+                    status="pending",
+                )
+            )
+            session.add(
+                PriceProposal(
+                    listing_id=active_listing,
+                    proposal_type="reprice_raise",
+                    current_price=500.0,
+                    suggested_price=600.0,
+                    reason="test2",
+                    status="executed",
+                )
+            )
+            session.commit()
+
+        result = service.list_proposals(status="pending")
+        assert result["count"] == 1
+        assert result["proposals"][0]["status"] == "pending"
+
+
+class TestApproveProposal:
+    def test_approves_and_executes(self, service, engine, active_listing, tradera):
+        with Session(engine) as session:
+            proposal = PriceProposal(
+                listing_id=active_listing,
+                proposal_type="reprice_lower",
+                current_price=500.0,
+                suggested_price=430.0,
+                reason="test",
+                status="pending",
+            )
+            session.add(proposal)
+            session.commit()
+            pid = proposal.id
+
+        result = service.approve_proposal(pid)
+
+        assert "error" not in result
+        assert result["status"] == "executed"
+        tradera.set_prices.assert_called_once()
+
+        # Verify DB state
+        with Session(engine) as session:
+            p = session.get(PriceProposal, pid)
+            assert p.status == "executed"
+            assert p.decided_at is not None
+            assert p.executed_at is not None
+
+    def test_approve_buy_it_now(self, service, engine, bin_listing, tradera):
+        with Session(engine) as session:
+            proposal = PriceProposal(
+                listing_id=bin_listing,
+                proposal_type="reprice_lower",
+                current_price=800.0,
+                suggested_price=680.0,
+                reason="test",
+                status="pending",
+                details={"listing_type": "buy_it_now"},
+            )
+            session.add(proposal)
+            session.commit()
+            pid = proposal.id
+
+        result = service.approve_proposal(pid)
+        assert "error" not in result
+        tradera.set_prices.assert_called_once_with(
+            item_id=67890,
+            listing_type="buy_it_now",
+            buy_it_now_price=680,
+        )
+
+    def test_not_found(self, service):
+        result = service.approve_proposal(9999)
+        assert "error" in result
+
+    def test_not_pending(self, service, engine, active_listing):
+        with Session(engine) as session:
+            proposal = PriceProposal(
+                listing_id=active_listing,
+                proposal_type="reprice_lower",
+                current_price=500.0,
+                suggested_price=430.0,
+                reason="test",
+                status="executed",
+            )
+            session.add(proposal)
+            session.commit()
+            pid = proposal.id
+
+        result = service.approve_proposal(pid)
+        assert "error" in result
+
+    def test_tradera_error_marks_failed(self, service, engine, active_listing, tradera):
+        tradera.set_prices.return_value = {"error": "Auction has bids"}
+
+        with Session(engine) as session:
+            proposal = PriceProposal(
+                listing_id=active_listing,
+                proposal_type="reprice_lower",
+                current_price=500.0,
+                suggested_price=430.0,
+                reason="test",
+                status="pending",
+            )
+            session.add(proposal)
+            session.commit()
+            pid = proposal.id
+
+        result = service.approve_proposal(pid)
+        assert result["status"] == "failed"
+
+        with Session(engine) as session:
+            p = session.get(PriceProposal, pid)
+            assert p.status == "failed"
+            assert p.execution_error == "Auction has bids"
+
+
+class TestRejectProposal:
+    def test_rejects_with_reason(self, service, engine, active_listing):
+        with Session(engine) as session:
+            proposal = PriceProposal(
+                listing_id=active_listing,
+                proposal_type="reprice_lower",
+                current_price=500.0,
+                suggested_price=430.0,
+                reason="test",
+                status="pending",
+            )
+            session.add(proposal)
+            session.commit()
+            pid = proposal.id
+
+        result = service.reject_proposal(pid, reason="Vill inte sänka")
+        assert result["status"] == "rejected"
+        assert result["reason"] == "Vill inte sänka"
+
+        with Session(engine) as session:
+            p = session.get(PriceProposal, pid)
+            assert p.status == "rejected"
+            assert p.decided_at is not None
+
+    def test_not_found(self, service):
+        result = service.reject_proposal(9999)
+        assert "error" in result
+
+    def test_not_pending(self, service, engine, active_listing):
+        with Session(engine) as session:
+            proposal = PriceProposal(
+                listing_id=active_listing,
+                proposal_type="reprice_lower",
+                current_price=500.0,
+                suggested_price=430.0,
+                reason="test",
+                status="rejected",
+            )
+            session.add(proposal)
+            session.commit()
+            pid = proposal.id
+
+        result = service.reject_proposal(pid)
+        assert "error" in result
+
+
+class TestComputeSuggestedPrice:
+    def test_lower_reduces_15_percent(self):
+        product = MagicMock(acquisition_cost=None)
+        result = RepricingService._compute_suggested_price(1000, "reprice_lower", product)
+        assert result == 850
+
+    def test_lower_rounds_to_nearest_10(self):
+        product = MagicMock(acquisition_cost=None)
+        result = RepricingService._compute_suggested_price(333, "reprice_lower", product)
+        # 333 * 0.85 = 283.05 → ceil(283.05 / 10) * 10 = 290
+        assert result == 290
+
+    def test_lower_floor_at_acquisition_cost(self):
+        product = MagicMock(acquisition_cost=400.0)
+        # 500 * 0.85 = 425, ceil(425/10)*10 = 430
+        # floor = ceil(400 * 1.1 / 10) * 10 = 450 (float rounding: 400*1.1=440.00...06)
+        result = RepricingService._compute_suggested_price(500, "reprice_lower", product)
+        assert result == 450
+
+    def test_raise_increases_20_percent(self):
+        product = MagicMock(acquisition_cost=None)
+        result = RepricingService._compute_suggested_price(1000, "reprice_raise", product)
+        assert result == 1200
+
+    def test_raise_rounds_to_nearest_10(self):
+        product = MagicMock(acquisition_cost=None)
+        result = RepricingService._compute_suggested_price(333, "reprice_raise", product)
+        # 333 * 1.20 = 399.6 → ceil(399.6 / 10) * 10 = 400
+        assert result == 400
+
+    def test_minimum_10_kr(self):
+        product = MagicMock(acquisition_cost=None)
+        result = RepricingService._compute_suggested_price(5, "reprice_lower", product)
+        assert result >= 10
+
+    def test_no_product_for_lower(self):
+        result = RepricingService._compute_suggested_price(1000, "reprice_lower", None)
+        assert result == 850

--- a/tests/test_repricing.py
+++ b/tests/test_repricing.py
@@ -161,6 +161,45 @@ class TestGenerateProposals:
         result = service.generate_proposals()
         assert "error" in result
 
+    def test_auction_with_bin_uses_start_price_as_baseline(self, service, marketing, engine):
+        """For auction listings with BIN set, baseline must be start_price (not BIN)."""
+        with Session(engine) as session:
+            p = Product(title="Mixed", status="listed", acquisition_cost=100.0)
+            session.add(p)
+            session.flush()
+            listing = PlatformListing(
+                product_id=p.id,
+                platform="tradera",
+                status="active",
+                listing_type="auction",
+                listing_title="Mixed auction",
+                start_price=300.0,
+                buy_it_now_price=500.0,
+                external_id="55555",
+            )
+            session.add(listing)
+            session.commit()
+            lid = listing.id
+
+        marketing.get_recommendations.return_value = {
+            "recommendations": [
+                {
+                    "listing_id": lid,
+                    "type": "reprice_lower",
+                    "priority": "medium",
+                    "suggestion": "Sänk priset.",
+                },
+            ],
+        }
+
+        result = service.generate_proposals()
+        assert result["new_proposals"] == 1
+        proposal = result["proposals"][0]
+        # Baseline is start_price (300), not buy_it_now_price (500)
+        assert proposal["current_price"] == 300.0
+        # 300 * 0.85 = 255 → ceil(255/10)*10 = 260
+        assert proposal["suggested_price"] == 260
+
 
 class TestListProposals:
     def test_lists_all_proposals(self, service, engine, active_listing):
@@ -364,6 +403,7 @@ class TestRejectProposal:
             p = session.get(PriceProposal, pid)
             assert p.status == "rejected"
             assert p.decided_at is not None
+            assert p.details["rejection_reason"] == "Vill inte sänka"
 
     def test_not_found(self, service):
         result = service.reject_proposal(9999)
@@ -429,7 +469,7 @@ class TestComputeSuggestedPrice:
 
 class TestConstants:
     def test_proposal_statuses(self):
-        assert PROPOSAL_STATUSES == {"pending", "approved", "rejected", "executed", "failed"}
+        assert PROPOSAL_STATUSES == {"pending", "rejected", "executed", "failed"}
 
     def test_proposal_types(self):
         assert PROPOSAL_TYPES == {"reprice_lower", "reprice_raise"}

--- a/tests/test_repricing.py
+++ b/tests/test_repricing.py
@@ -436,13 +436,22 @@ class TestComputeSuggestedPrice:
     def test_lower_rounds_to_nearest_10(self):
         product = MagicMock(acquisition_cost=None)
         result = RepricingService._compute_suggested_price(333, "reprice_lower", product)
-        # 333 * 0.85 = 283.05 → ceil(283.05 / 10) * 10 = 290
-        assert result == 290
+        # 333 * 0.85 = 283.05 → round(283.05 / 10) * 10 = 280
+        assert result == 280
 
     def test_lower_floor_at_acquisition_cost(self):
         product = MagicMock(acquisition_cost=400.0)
-        # 500 * 0.85 = 425, ceil(425/10)*10 = 430
-        # floor = ceil(400 * 1.1 / 10) * 10 = 450 (float rounding: 400*1.1=440.00...06)
+        # 500 * 0.85 = 425, round(425/10)*10 = 420 (banker's rounding: 42.5 → 42)
+        # floor = ceil(round(400 * 1.1, 2) / 10) * 10 = ceil(440.0 / 10) * 10 = 440
+        # max(420, 440) = 440
+        result = RepricingService._compute_suggested_price(500, "reprice_lower", product)
+        assert result == 440
+
+    def test_lower_floor_rounds_up_to_next_10(self):
+        product = MagicMock(acquisition_cost=405.0)
+        # 500 * 0.85 = 425, round(425/10)*10 = 420
+        # floor = ceil(round(405 * 1.1, 2) / 10) * 10 = ceil(445.5 / 10) * 10 = 450
+        # max(420, 450) = 450
         result = RepricingService._compute_suggested_price(500, "reprice_lower", product)
         assert result == 450
 
@@ -454,7 +463,7 @@ class TestComputeSuggestedPrice:
     def test_raise_rounds_to_nearest_10(self):
         product = MagicMock(acquisition_cost=None)
         result = RepricingService._compute_suggested_price(333, "reprice_raise", product)
-        # 333 * 1.20 = 399.6 → ceil(399.6 / 10) * 10 = 400
+        # 333 * 1.20 = 399.6 → round(399.6 / 10) * 10 = 400
         assert result == 400
 
     def test_minimum_10_kr(self):

--- a/tests/test_repricing.py
+++ b/tests/test_repricing.py
@@ -6,7 +6,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from storebot.db import PlatformListing, PriceProposal, Product
-from storebot.tools.repricing import RepricingService
+from storebot.tools.repricing import PROPOSAL_STATUSES, PROPOSAL_TYPES, RepricingService
 
 
 @pytest.fixture
@@ -151,6 +151,16 @@ class TestGenerateProposals:
         result = service.generate_proposals()
         assert result["new_proposals"] == 0
 
+    def test_skip_refresh(self, service, marketing, active_listing):
+        marketing.get_recommendations.return_value = {"recommendations": []}
+        service.generate_proposals(skip_refresh=True)
+        marketing.refresh_listing_stats.assert_not_called()
+
+    def test_refresh_failure_returns_error(self, service, marketing):
+        marketing.refresh_listing_stats.side_effect = RuntimeError("Tradera down")
+        result = service.generate_proposals()
+        assert "error" in result
+
 
 class TestListProposals:
     def test_lists_all_proposals(self, service, engine, active_listing):
@@ -198,6 +208,10 @@ class TestListProposals:
         result = service.list_proposals(status="pending")
         assert result["count"] == 1
         assert result["proposals"][0]["status"] == "pending"
+
+    def test_invalid_status_returns_error(self, service):
+        result = service.list_proposals(status="INVALID")
+        assert "error" in result
 
 
 class TestApproveProposal:
@@ -271,6 +285,36 @@ class TestApproveProposal:
 
         result = service.approve_proposal(pid)
         assert "error" in result
+
+    def test_listing_deactivated_after_proposal_created(self, service, engine, active_listing):
+        """Listing became inactive between proposal creation and approval."""
+        with Session(engine) as session:
+            proposal = PriceProposal(
+                listing_id=active_listing,
+                proposal_type="reprice_lower",
+                current_price=500.0,
+                suggested_price=430.0,
+                reason="test",
+                status="pending",
+            )
+            session.add(proposal)
+            session.commit()
+            pid = proposal.id
+
+        # Deactivate the listing
+        with Session(engine) as session:
+            listing = session.get(PlatformListing, active_listing)
+            listing.status = "ended"
+            session.commit()
+
+        result = service.approve_proposal(pid)
+        assert "error" in result
+        assert "no longer active" in result["error"]
+
+        with Session(engine) as session:
+            p = session.get(PriceProposal, pid)
+            assert p.status == "failed"
+            assert p.executed_at is not None
 
     def test_tradera_error_marks_failed(self, service, engine, active_listing, tradera):
         tradera.set_prices.return_value = {"error": "Auction has bids"}
@@ -381,3 +425,11 @@ class TestComputeSuggestedPrice:
     def test_no_product_for_lower(self):
         result = RepricingService._compute_suggested_price(1000, "reprice_lower", None)
         assert result == 850
+
+
+class TestConstants:
+    def test_proposal_statuses(self):
+        assert PROPOSAL_STATUSES == {"pending", "approved", "rejected", "executed", "failed"}
+
+    def test_proposal_types(self):
+        assert PROPOSAL_TYPES == {"reprice_lower", "reprice_raise"}

--- a/tests/test_tradera.py
+++ b/tests/test_tradera.py
@@ -1570,3 +1570,56 @@ class TestGetShippingTypesEdgeCases:
         client._public_client.service.GetShippingTypes.return_value = response
         result = client.get_shipping_types()
         assert result == {"shipping_types": []}
+
+
+class TestEndItem:
+    def test_success(self, client):
+        client._restricted_client.service.EndItem.return_value = None
+        result = client.end_item(12345)
+        assert result == {"item_id": 12345, "ended": True}
+        client._restricted_client.service.EndItem.assert_called_once()
+
+    def test_exception_returns_error(self, client):
+        client._restricted_client.service.EndItem.side_effect = Exception("SOAP fault")
+        result = client.end_item(12345)
+        assert "error" in result
+        assert "SOAP fault" in result["error"]
+
+
+class TestSetPrices:
+    def test_auction_set_start_price(self, client):
+        client._restricted_client.service.SetPricesOnNonShopItems.return_value = None
+        result = client.set_prices(item_id=100, listing_type="auction", start_price=300)
+        assert result["updated"] is True
+        assert result["start_price"] == 300
+        client._restricted_client.service.SetPricesOnNonShopItems.assert_called_once()
+
+    def test_auction_all_prices(self, client):
+        client._restricted_client.service.SetPricesOnNonShopItems.return_value = None
+        result = client.set_prices(
+            item_id=100,
+            listing_type="auction",
+            start_price=200,
+            reserve_price=500,
+            buy_it_now_price=800,
+        )
+        assert result["updated"] is True
+        assert result["start_price"] == 200
+        assert result["reserve_price"] == 500
+        assert result["buy_it_now_price"] == 800
+
+    def test_buy_it_now(self, client):
+        client._restricted_client.service.SetPriceOnShopItems.return_value = None
+        result = client.set_prices(item_id=200, listing_type="buy_it_now", buy_it_now_price=999)
+        assert result["updated"] is True
+        assert result["buy_it_now_price"] == 999
+        client._restricted_client.service.SetPriceOnShopItems.assert_called_once()
+
+    def test_buy_it_now_missing_price(self, client):
+        result = client.set_prices(item_id=200, listing_type="buy_it_now")
+        assert "error" in result
+
+    def test_exception_returns_error(self, client):
+        client._restricted_client.service.SetPricesOnNonShopItems.side_effect = Exception("fail")
+        result = client.set_prices(item_id=100, listing_type="auction", start_price=300)
+        assert "error" in result

--- a/tests/test_tradera.py
+++ b/tests/test_tradera.py
@@ -1619,6 +1619,11 @@ class TestSetPrices:
         result = client.set_prices(item_id=200, listing_type="buy_it_now")
         assert "error" in result
 
+    def test_all_none_prices_returns_error(self, client):
+        result = client.set_prices(item_id=100, listing_type="auction")
+        assert "error" in result
+        assert "At least one price" in result["error"]
+
     def test_exception_returns_error(self, client):
         client._restricted_client.service.SetPricesOnNonShopItems.side_effect = Exception("fail")
         result = client.set_prices(item_id=100, listing_type="auction", start_price=300)


### PR DESCRIPTION
## Summary

- **RepricingService** — New service with daily price proposal workflow: `generate_proposals`, `list_proposals`, `approve_proposal`, `reject_proposal`. Proposals are stored in a new `price_proposals` table with full lifecycle tracking (pending → approved/rejected → executed/failed).
- **Tradera SOAP write operations** — `TraderaClient.end_item()` (EndItem) and `set_prices()` (SetPricesOnNonShopItems / SetPriceOnShopItems) for managing live listings directly on Tradera.
- **ListingService extensions** — `end_tradera_listing()` ends a live auction via SOAP + updates local status; `update_live_listing_price()` changes prices on live listings; `cancel_listing()` now attempts best-effort Tradera EndItem.
- **5 new agent tools** — `list_price_proposals`, `approve_price_proposal`, `reject_price_proposal`, `end_tradera_listing`, `update_tradera_listing_price`
- **Scheduled Telegram digest** — Daily `repricing_check_job` generates proposals and sends Swedish-language summary to owner
- **Code quality improvements** — Extracted `_maybe_revert_product_status` helper (eliminated 3x duplication), bulk query in `generate_proposals` (N+1 → 1 query), batched flush, `PROPOSAL_STATUSES`/`PROPOSAL_TYPES` constants

## Test plan

- [x] `ruff check src/ tests/` — all lint checks pass
- [x] `ruff format --check src/ tests/` — all files formatted
- [x] `pytest` — 1144 tests pass (70 new tests across test_repricing, test_tradera, test_listing, test_handlers, test_dispatch, test_mcp_server)
- [ ] Manual smoke test: create listing in sandbox, run `generate_proposals()`, approve a proposal, verify Tradera SOAP call

🤖 Generated with [Claude Code](https://claude.com/claude-code)