### PR TITLE
fix: address fourth round of repricing review findings

### DIFF
--- a/src/storebot/bot/handlers.py
+++ b/src/storebot/bot/handlers.py
@@ -527,7 +527,7 @@ async def repricing_check_job(context: ContextTypes.DEFAULT_TYPE) -> None:
         for p in proposals:
             direction = "Sänk" if p["proposal_type"] == "reprice_lower" else "Höj"
             lines.append(
-                f"{direction}: {p.get('listing_title', 'Annons #' + str(p['listing_id']))}"
+                f"{direction}: {p.get('listing_title') or 'Annons #' + str(p['listing_id'])}"
             )
             lines.append(f"  {p['current_price']:.0f} kr \u2192 {p['suggested_price']:.0f} kr")
             lines.append(f"  {p['reason']}\n")

--- a/src/storebot/db.py
+++ b/src/storebot/db.py
@@ -252,7 +252,7 @@ class PriceProposal(Base):
     current_price: Mapped[float] = mapped_column(Float, nullable=False)
     suggested_price: Mapped[float] = mapped_column(Float, nullable=False)
     reason: Mapped[str] = mapped_column(Text, nullable=False)
-    status: Mapped[str] = mapped_column(String, default="pending")
+    status: Mapped[str] = mapped_column(String, default="pending", server_default="pending")
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
     decided_at: Mapped[datetime | None] = mapped_column(DateTime)
     executed_at: Mapped[datetime | None] = mapped_column(DateTime)

--- a/src/storebot/tools/repricing.py
+++ b/src/storebot/tools/repricing.py
@@ -45,7 +45,11 @@ class RepricingService:
             except Exception:
                 logger.exception("refresh_listing_stats failed during proposal generation")
                 return {"error": "Failed to refresh listing stats"}
-        recs_result = self.marketing.get_recommendations()
+        try:
+            recs_result = self.marketing.get_recommendations()
+        except Exception:
+            logger.exception("get_recommendations failed during proposal generation")
+            return {"error": "Failed to get recommendations"}
         recs = recs_result.get("recommendations", [])
 
         reprice_recs = [r for r in recs if r["type"] in PROPOSAL_TYPES]
@@ -248,7 +252,10 @@ class RepricingService:
             }
 
     def _execute_proposal(self, proposal: PriceProposal, session: Session) -> dict:
-        """Execute an approved price change via Tradera."""
+        """Execute an approved price change via Tradera.
+
+        Caller must set ``proposal.decided_at`` before calling this method.
+        """
         if not self.tradera:
             proposal.status = "failed"
             proposal.executed_at = datetime.now(UTC)
@@ -327,7 +334,8 @@ class RepricingService:
             raw = current_price * 0.85
             suggested = int(round(raw / 10) * 10)
             if product and product.acquisition_cost:
-                # acquisition_cost is the gross (VAT-inclusive) purchase price
+                # acquisition_cost is the gross (VAT-inclusive) purchase price;
+                # round(..., 2) avoids IEEE 754 noise (e.g. 400*1.1 = 440.00000006)
                 floor = int(math.ceil(round(product.acquisition_cost * 1.1, 2) / 10) * 10)
                 suggested = max(suggested, floor)
         else:

--- a/tests/test_repricing.py
+++ b/tests/test_repricing.py
@@ -161,6 +161,12 @@ class TestGenerateProposals:
         result = service.generate_proposals()
         assert "error" in result
 
+    def test_get_recommendations_failure_returns_error(self, service, marketing):
+        marketing.get_recommendations.side_effect = RuntimeError("DB error")
+        result = service.generate_proposals(skip_refresh=True)
+        assert "error" in result
+        assert "recommendations" in result["error"]
+
     def test_auction_with_bin_uses_start_price_as_baseline(self, service, marketing, engine):
         """For auction listings with BIN set, baseline must be start_price (not BIN)."""
         with Session(engine) as session:


### PR DESCRIPTION
## Summary
- Add `server_default="pending"` to `PriceProposal.status` ORM model (matches migration)
- Wrap `get_recommendations()` in try/except for consistent error handling
- Fix `listing_title` None fallback (`or` pattern instead of `dict.get` default)
- Add docstring contract on `_execute_proposal` re: `decided_at`
- Add float precision comment on `round(..., 2)` guard
- New test for `get_recommendations` failure path

## Test plan
- [x] 1157 tests passing
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)